### PR TITLE
Contest info to state

### DIFF
--- a/src/lib/contest.ts
+++ b/src/lib/contest.ts
@@ -25,7 +25,7 @@ import type {
 	SubmissionJSON,
 	TeamJSON
 } from './contest-types';
-import { CONTEST_PASSWORD, CONTEST_URL, CONTEST_USER } from './hardcoded';
+import { CONTEST } from './hardcoded.svelte';
 
 export class Contest {
 	info?: ContestJSON;
@@ -76,8 +76,8 @@ export class Contest {
 		const httpsOptions: HttpsOptions = {
 			rejectUnauthorized: false
 		};
-		const user = CONTEST_USER;
-		const password = CONTEST_PASSWORD;
+		const user = CONTEST.user;
+		const password = CONTEST.password;
 		const options: OptionsOfTextResponseBody = {
 			https: httpsOptions,
 			retry: { limit: 0 },
@@ -360,7 +360,7 @@ export class Contest {
 	resolveURL(ref: FileReferenceJSON | undefined): string | undefined {
 		if (!ref || !ref.href) return undefined;
 		// TODO: for now, hack off part of the URL
-		return this.contestURL.substring(0, CONTEST_URL.length) + ref.href;
+		return this.contestURL.substring(0, CONTEST.url.length) + ref.href;
 	}
 
 	clear() {

--- a/src/lib/hardcoded.svelte.ts
+++ b/src/lib/hardcoded.svelte.ts
@@ -1,0 +1,5 @@
+export const CONTEST = $state({
+    url: process?.env?.CONTEST_URL || 'https://localhost:8443/api/',
+    user: process?.env?.CONTEST_USER || 'admin',
+    password: process?.env?.CONTEST_PASSWORD || 'adm1n'
+});

--- a/src/lib/hardcoded.ts
+++ b/src/lib/hardcoded.ts
@@ -1,3 +1,0 @@
-export const CONTEST_URL: string = process.env.CONTEST_URL || 'https://localhost:8443/api/';
-export const CONTEST_USER: string = process.env.CONTEST_USER || 'admin';
-export const CONTEST_PASSWORD: string = process.env.CONTEST_PASSWORD || 'adm1n';

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,7 +1,7 @@
 import { Contests } from "./contests";
-import { CONTEST_URL } from "./hardcoded";
+import { CONTEST } from "./hardcoded.svelte";
 
-const contestsImpl = new Contests(CONTEST_URL);
+const contestsImpl = new Contests(CONTEST.url);
 
 await contestsImpl.loadContests();
 

--- a/src/lib/ui/Banner.svelte
+++ b/src/lib/ui/Banner.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import type { FileReferenceJSON } from '$lib/contest-types';
-	import { CONTEST_URL } from '$lib/hardcoded';
+	import { CONTEST } from '$lib/hardcoded.svelte';
 	import Image from './Image.svelte';
 
-	export let url: string = CONTEST_URL + 'contests';
+	export let url: string = CONTEST.url + 'contests';
 	export let ref: FileReferenceJSON[] | undefined;
 	export let size: 16 | 24 | 32 | 64 = 16;
 </script>

--- a/src/lib/ui/Image.svelte
+++ b/src/lib/ui/Image.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import type { FileReferenceJSON } from '$lib/contest-types';
-	import { CONTEST_URL } from '$lib/hardcoded';
+	import { CONTEST } from '$lib/hardcoded.svelte';
 	import { ContestUtil } from '../contest-util';
 
-	export let url: string = CONTEST_URL + 'contests';
+	export let url: string = CONTEST.url + 'contests';
 	export let ref: FileReferenceJSON[] | undefined;
 	export let size: number;
 
 	const util = new ContestUtil();
 	const bestRef = util.bestSquareLogo(ref, size * 20);
-	const imgSrc = url.substring(0, CONTEST_URL.length) + bestRef?.href;
+	const imgSrc = url.substring(0, CONTEST.url.length) + bestRef?.href;
 </script>
 
 {#if bestRef}

--- a/src/lib/ui/Logo.svelte
+++ b/src/lib/ui/Logo.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import type { FileReferenceJSON } from '$lib/contest-types';
-	import { CONTEST_URL } from '$lib/hardcoded';
+	import { CONTEST } from '$lib/hardcoded.svelte';
 	import Image from './Image.svelte';
 
-	export let url: string = CONTEST_URL + 'contests';
+	export let url: string = CONTEST.url + 'contests';
 	export let ref: FileReferenceJSON[] | undefined;
 	export let size: number = 8;
 </script>

--- a/src/lib/ui/Photo.svelte
+++ b/src/lib/ui/Photo.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import type { FileReferenceJSON } from '$lib/contest-types';
-	import { CONTEST_URL } from '$lib/hardcoded';
+	import { CONTEST } from '$lib/hardcoded.svelte';
 	import Image from './Image.svelte';
 
-	export let url: string = CONTEST_URL + 'contests';
+	export let url: string = CONTEST.url + 'contests';
 	export let ref: FileReferenceJSON[] | undefined;
 	let size = 24;
 </script>

--- a/src/lib/ui/Video.svelte
+++ b/src/lib/ui/Video.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 	import type { FileReferenceJSON } from '$lib/contest-types';
-	//import { CONTEST_URL } from '$lib/hardcoded';
 	import { ContestUtil } from '../contest-util';
 
-	//export let url: string = CONTEST_URL + 'contests';
 	export let ref: FileReferenceJSON[] | undefined;
 	export let type: string;
 


### PR DESCRIPTION
I think this change should convince Svelte that the contest info is state and should not be optimized away. If not, it is at least one step closer, and slightly more readable code using a CONTEST object instead of individual properties.

Possible first part of a fix for #3.