### PR TITLE
Svelte 5 params and fileref util

### DIFF
--- a/src/lib/fileref-util.ts
+++ b/src/lib/fileref-util.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright later.
+ */
+import type { FileReferenceJSON } from '$lib/contest-types';
+import { CONTEST } from '$lib/hardcoded.svelte';
+
+export function resolveFileRef(ref: FileReferenceJSON | undefined): string | undefined {
+	if (!ref)
+		return undefined;
+
+	const url: string = CONTEST.url + 'contests';
+	return url.substring(0, CONTEST.url.length) + ref?.href;
+}

--- a/src/lib/ui/Banner.svelte
+++ b/src/lib/ui/Banner.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import type { FileReferenceJSON } from '$lib/contest-types';
-	import { CONTEST } from '$lib/hardcoded.svelte';
 	import Image from './Image.svelte';
 
-	export let url: string = CONTEST.url + 'contests';
-	export let ref: FileReferenceJSON[] | undefined;
-	export let size: 16 | 24 | 32 | 64 = 16;
+	interface Props {
+		ref?: FileReferenceJSON[];
+		size: 16 | 24 | 32 | 64;
+	}
+
+	let { ref, size = 16 }: Props = $props();
 </script>
 
 <div class="max-h-{size} h-{size} flex place-content-center">
-  <Image {url} {ref} {size} />
+  <Image {ref} {size} />
 </div>

--- a/src/lib/ui/Image.svelte
+++ b/src/lib/ui/Image.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
 	import type { FileReferenceJSON } from '$lib/contest-types';
-	import { CONTEST } from '$lib/hardcoded.svelte';
+	import { resolveFileRef } from '$lib/fileref-util';
 	import { ContestUtil } from '../contest-util';
 
-	export let url: string = CONTEST.url + 'contests';
-	export let ref: FileReferenceJSON[] | undefined;
-	export let size: number;
+	interface Props {
+		ref?: FileReferenceJSON[];
+		size: number;
+	}
+
+	let { ref, size }: Props = $props();
 
 	const util = new ContestUtil();
 	const bestRef = util.bestSquareLogo(ref, size * 20);
-	const imgSrc = url.substring(0, CONTEST.url.length) + bestRef?.href;
+	const imgSrc = resolveFileRef(bestRef);
 </script>
 
 {#if bestRef}

--- a/src/lib/ui/Logo.svelte
+++ b/src/lib/ui/Logo.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import type { FileReferenceJSON } from '$lib/contest-types';
-	import { CONTEST } from '$lib/hardcoded.svelte';
 	import Image from './Image.svelte';
 
-	export let url: string = CONTEST.url + 'contests';
-	export let ref: FileReferenceJSON[] | undefined;
-	export let size: number = 8;
+	interface Props {
+		ref?: FileReferenceJSON[];
+		size: number;
+	}
+
+	let { ref, size = 8 }: Props = $props();
 </script>
 
 <div class="max-h-{size} max-w-{size} h-{size} w-{size} flex place-content-center">
-  <Image {url} {ref} {size} />
+  <Image {ref} {size} />
 </div>

--- a/src/lib/ui/Person.svelte
+++ b/src/lib/ui/Person.svelte
@@ -2,7 +2,11 @@
 	import type { PersonJSON } from '$lib/contest-types';
 	import Image from './Image.svelte';
 
-	export let person: PersonJSON;
+	interface Props {
+		person: PersonJSON;
+	}
+
+	let { person }: Props = $props();
 </script>
 
 <div class="flex flex-col items-center border-[1px] bg-gray-200 gap-2">

--- a/src/lib/ui/Photo.svelte
+++ b/src/lib/ui/Photo.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import type { FileReferenceJSON } from '$lib/contest-types';
-	import { CONTEST } from '$lib/hardcoded.svelte';
 	import Image from './Image.svelte';
 
-	export let url: string = CONTEST.url + 'contests';
-	export let ref: FileReferenceJSON[] | undefined;
-	let size = 24;
+	interface Props {
+		ref?: FileReferenceJSON[];
+		size: number;
+	}
+
+	let { ref, size = 24 }: Props = $props();
 </script>
 
 <div class="max-h-{size} max-w-{size} h-{size} w-{size} flex place-content-center">
-  <Image {url} {ref} size={size} />
+  <Image {ref} size={size} />
 </div>


### PR DESCRIPTION
Switches all the lib/ui files to Svelte 5 property syntax, removing unused url property on many of them.

Adds fileref-util.ts that does the same overly simplistic file ref resolving as before, but at least in a single place so that we can fix it later.