### PR TITLE
Scoreboard support for scoring contests

### DIFF
--- a/src/lib/color-util.ts
+++ b/src/lib/color-util.ts
@@ -1,6 +1,12 @@
 /**
  * Copyright later.
  */
+export const PENDING = rgbToHex([66, 114, 245]);
+export const FAILED = rgbToHex([240, 0, 0]);
+export const SOLVED = rgbToHex([0, 230, 0]);
+export const SCORING_MID = rgbToHex([210, 210, 0]);
+export const FIRST_TO_SOLVE = rgbToHex([0, 100, 0]);
+
 export function parseHexColor(hex: string): [number, number, number] | [number, number, number, number] {
 	// remove the '#' if present
 	const cleanHex = hex.startsWith('#') ? hex.slice(1) : hex;
@@ -50,6 +56,6 @@ export function rgbToHex(color: number[]): string {
 }
 
 export function colorToHex(c: number): string {
-	const hex = c.toString(16);
+	const hex = Math.floor(c).toString(16);
 	return hex.length === 1 ? "0" + hex : hex;
 }

--- a/src/lib/contest-types.ts
+++ b/src/lib/contest-types.ts
@@ -20,7 +20,7 @@ export interface ContestJSON {
 	start_time?: string;
 	duration: RelTime;
 	scoreboard_freeze_duration?: RelTime;
-	scoreboard_type: 'pass-fail' | 'scoring';
+	scoreboard_type: 'pass-fail' | 'score';
 	penalty_time?: number | RelTime; // 2023-06 | draft
 	countdown_pause_time?: RelTime;
 	banner?: FileReferenceJSON[];

--- a/src/routes/scoreboard/+page.server.ts
+++ b/src/routes/scoreboard/+page.server.ts
@@ -38,6 +38,7 @@ export const load = async (_params) => {
 
 	return {
 		name: info.name,
+		scoreboard_type: info.scoreboard_type,
 		scoreboard: scoreboard,
 		teams: sortedTeams,
 		logos: logos,


### PR DESCRIPTION
Changes the scoreboard to use the 'correct' ICPC tools colours for solved and failed problems. Then adds support for scoring contests, replacing the solved/penalty columns with score and shading the cells between green and red when the problem max_score is set.