### PR TITLE
Update team submission list to table

### DIFF
--- a/src/lib/contest.ts
+++ b/src/lib/contest.ts
@@ -162,8 +162,8 @@ export class Contest {
 	}
 
 	async loadLanguages(): Promise<LanguageJSON[] | undefined> {
-		this.problems = await this.loadObject('problems');
-		return this.problems;
+		this.languages = await this.loadObject('languages');
+		return this.languages;
 	}
 
 	async loadJudgementTypes(): Promise<JudgementTypeJSON[] | undefined> {

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
 	import Person from '$lib/ui/Person.svelte';
-	import * as countries from 'i18n-iso-countries';
-	import en from 'i18n-iso-countries/langs/en.json';
-
-	countries.registerLocale(en);
-
+	
 	let { data } = $props();
 </script>
 
@@ -24,7 +20,7 @@
 {#if data.organization?.country}
 <div class="flex flex-col">
 	<div class="text-xl">Country</div>
-	<div>{countries.getName(data.organization.country, 'en')}</div>
+	<div>{data.country}</div>
 </div>
 {/if}
 
@@ -56,8 +52,19 @@
 {#if data.submissions && data.submissions.length > 0}
 <div class="flex flex-col">
 <div class="text-xl">Submissions</div>
+<div class="grid grid-table" style="grid-template-columns: 1fr 1fr 1fr 1fr" role="row">
+  <div role="cell" class="">Time</div>
+  <div role="cell" class="">Problem</div>
+  <div role="cell" class="">Language</div>
+  <div role="cell" class="">Judgement</div>
+</div>
 {#each data.submissions as submission}
-<div class="flex flex-row">{submission.contest_time}</div>
+<div class="grid grid-table" style="grid-template-columns: 1fr 1fr 1fr 1fr" role="row">
+  <div role="cell" class="">{submission.time}</div>
+  <div role="cell" class="">{submission.problem}</div>
+  <div role="cell" class="">{submission.language}</div>
+  <div role="cell" class="">{submission.judgement}</div>
+</div>
 {/each}
 </div>
 {/if}


### PR DESCRIPTION
The team detail page had a list of submission times with no details. This changes it to include a table of submissions instead, with columns for time, problem, language and judgement. It's basic for now, but much more useful than the prior list.

Also moves the country name calculation to server-side - but disables it for now as I'm having trouble with it.