### PR TITLE
Allow contest url without /

### DIFF
--- a/src/lib/contest-api.ts
+++ b/src/lib/contest-api.ts
@@ -50,26 +50,34 @@ export class ContestAPI {
 	scoreboard?: Scoreboard;
 
 	contestURL: string;
+	baseURL: string;
+	serverURL: string;
 
 	timeDelta = [];
 
-	/*constructor(baseURL: string, contestId: string) {
-		if (!baseURL.endsWith('/'))
-			baseURL += '/';
-		this.contestURL = baseURL + 'contests/' + contestId;
-		console.log("Contest URL: " + this.contestURL);
-	}*/
-
 	constructor(contestURL: string) {
+		if (!contestURL.endsWith('/')) {
+			contestURL += '/';
+		}
 		this.contestURL = contestURL;
+
+		// base url, e.g. http://example.com/api/
+		const bInd = this.contestURL.indexOf('/api/contests/');
+		this.baseURL = this.contestURL.substring(0, bInd + 5);
+
+		// server url, e.g. http://example.com
+		const sInd = this.contestURL.indexOf('//');
+		const sInd2 = this.contestURL.indexOf('/', sInd + 2);
+		this.serverURL = this.contestURL.substring(0, sInd2);
+
 		console.log('Contest URL: ' + this.contestURL);
 	}
 
 	getURL(type: any, id?: string) {
 		if (id == null) {
-			return this.contestURL + '/' + type;
+			return this.contestURL + type;
 		}
-		return this.contestURL + '/' + type + '/' + id;
+		return this.contestURL + type + '/' + id;
 	}
 
 	getHttpOptions(): OptionsOfTextResponseBody {
@@ -362,8 +370,12 @@ export class ContestAPI {
 		if (ref.href.startsWith('http://') || ref.href.startsWith('https://')) {
 			return ref.href;
 		}
-		// For relative URLs, prefix with contest URL base
-		return this.contestURL.substring(0, CONTEST.url.length) + ref.href;
+		// Prepend server-relative URLs
+		if (ref.href.startsWith('/')) {
+			return this.serverURL + ref.href;
+		}
+		// ... and base-relative URLs
+		return this.baseURL + ref.href;
 	}
 
 	private isFileReference(obj: any): obj is FileReference {

--- a/src/lib/contests.ts
+++ b/src/lib/contests.ts
@@ -13,7 +13,9 @@ export class Contests {
 	baseURL: string;
 
 	constructor(baseURL: string) {
-		if (!baseURL.endsWith('/')) baseURL += '/';
+		if (!baseURL.endsWith('/')) {
+			baseURL += '/';
+		}
 		this.baseURL = baseURL;
 		console.log('Contest API URL: ' + this.baseURL);
 	}
@@ -74,16 +76,13 @@ export class Contests {
 		if (!this.contests || this.contests.length === 0) {
 			return undefined;
 		}
-		let baseURL = this.baseURL;
-		if (!baseURL.endsWith('/')) baseURL += '/';
-		let contestURL = baseURL + 'contests/';
-		if (CONTEST.contest_id) {
+		let contestURL = this.baseURL + 'contests/';
+		if (CONTEST.contest_id && CONTEST.contest_id.length > 0) {
 			contestURL += CONTEST.contest_id;
 		} else {
 			contestURL += this.contests[0].id;
 		}
-		const c: ContestAPI = new ContestAPI(contestURL);
-		return c;
+		return new ContestAPI(contestURL);
 	}
 
 	getContestObjs(): Contest[] | undefined {


### PR DESCRIPTION
Automatically fix baseurls which are missing the trailing slash.

Fixes #19.