### PR TITLE
Scoreboard components

### DIFF
--- a/src/lib/ui/ScoreboardHeader.svelte
+++ b/src/lib/ui/ScoreboardHeader.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { parseHexColor, darker, rgbToHex } from '$lib/color-util.js';
+	import type { ProblemJSON } from '$lib/contest-types.js';
+	import { getColumns } from './scoreboard-util';
+
+	interface Props {
+		showLogo?: boolean;
+		scoreboard_type?: 'pass-fail' | 'score';
+		problems: ProblemJSON[];
+	}
+
+	let { scoreboard_type = 'pass-fail', problems, showLogo = true }: Props = $props();
+
+	let col = getColumns(scoreboard_type, problems?.length, showLogo);
+
+	let pStyle: string[] = [];
+	problems.forEach((p) => {
+		if (p.rgb) {
+			let col = parseHexColor(p.rgb);
+			let fg = '#fff';
+			if (col && col[0] + col[1] + col[2] > 450) {
+				fg = '#000';
+			}
+			let border = p.rgb;
+			if (col) {
+				border = rgbToHex(darker(col));
+			}
+
+			pStyle.push('background-color:' + p.rgb + ';color:' + fg + ';border-color:' + border + ';');
+		} else {
+			pStyle.push('background-color:#fff;color:#000;border:#000;');
+		}
+	});
+</script>
+
+<div role="rowgroup" class="sticky top-0 bg-white/90 font-semibold">
+	<div
+		role="row"
+		class="grid grid-table gap-x-0.5 min-h-7 py-2"
+		style="grid-template-columns: {col}">
+		<div role="cell">Rank</div>
+		{#if showLogo}
+			<div role="cell"></div>
+		{/if}
+		<div role="cell">Team</div>
+		{#if scoreboard_type === 'pass-fail'}
+			<div role="cell" class="justify-self-center">Solved</div>
+			<div role="cell" class="justify-self-center">Penalty</div>
+		{:else if scoreboard_type === 'score'}
+			<div role="cell" class="justify-self-center">Score</div>
+		{/if}
+		{#each problems as problem, ind}
+			<a class="justify-self-center" href="/problem/{problem.id}">
+				<div
+					role="cell"
+					class="text-center uppercase border-[1px] rounded-md w-12 h-6"
+					style={pStyle[ind]}>
+					{problem.label}
+				</div>
+			</a>
+		{/each}
+	</div>
+</div>

--- a/src/lib/ui/ScoreboardRow.svelte
+++ b/src/lib/ui/ScoreboardRow.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	import Logo from './Logo.svelte';
+	import { parseHexColor, rgbToHex, FAILED, SOLVED, PENDING, SCORING_MID } from '$lib/color-util.js';
+	import { timeToMin } from '$lib/contest-time-util.js';
+	import type { FileReferenceJSON, ProblemJSON, ScoreboardProblemJSON, ScoreboardRowJSON, TeamJSON } from '$lib/contest-types.js';
+	import { getColumns } from './scoreboard-util';
+
+	interface Props {
+		showLogo?: boolean;
+		scoreboard_type?: 'pass-fail' | 'score';
+		row: ScoreboardRowJSON;
+		problems: ProblemJSON[];
+		team?: TeamJSON;
+		logo?: FileReferenceJSON[];
+	}
+
+	let { scoreboard_type = 'pass-fail', problems, row, team, logo, showLogo = true }: Props = $props();
+
+	let col = getColumns(scoreboard_type, problems?.length, showLogo);
+
+	function scoreBg(rp: ScoreboardProblemJSON, problem: ProblemJSON):string {
+		if (rp.num_pending > 0) {
+			return PENDING;
+		}
+		if (scoreboard_type === 'pass-fail') {
+			if (rp.solved)
+				return SOLVED;
+		} else if (scoreboard_type === 'score') {
+			if (rp.score) {
+				if (problem.max_score) {
+					const percent = (rp.score ?? 0) / problem.max_score;
+
+					const c1 = parseHexColor(FAILED);
+					const c2 = parseHexColor(SCORING_MID);
+					const c3 = parseHexColor(SOLVED);
+					let cr = [0,0,0];
+					for (let i = 0; i < 3; i++) {
+						if (percent <= 0.5) {
+							cr[i] = c1[i] * (1 - percent * 2) + c2[i] * percent * 2;
+						} else {
+							cr[i] = c2[i] * (1 - (percent - 0.5) * 2) + c3[i] * (percent - 0.5) * 2;
+						}
+					}
+					return rgbToHex(cr);
+				} else {
+					return SOLVED;
+				}
+			}
+		}
+		if (rp.num_judged > 0 && rp.num_pending === 0)
+			return FAILED;
+		return '#333';
+	}
+</script>
+
+<div
+	role="row"
+	class="grid grid-table items-center min-h-7 even:bg-white odd:bg-gray-100 my-0.5 gap-x-0.5"
+	style="grid-template-columns: {col}">
+	<div role="cell" class="justify-self-center pr-1">{row.rank}</div>
+	{#if showLogo}
+		<div role="cell" class="w-4 justify-self-center"><Logo ref={logo} /></div>
+	{/if}
+	<div role="cell" class="text-nowrap overflow-hidden text-ellipsis">
+		<a href="/team/{team?.id}"
+			>{team?.display_name || team?.name}</a>
+	</div>
+
+	{#if scoreboard_type === 'pass-fail'}
+		<div role="cell" class="justify-self-center text-xl">
+			{row.score.num_solved && row.score.num_solved > 0 ? row.score.num_solved : ''}
+		</div>
+		<div role="cell" class="justify-self-center">
+			{timeToMin(row.score.total_time)}
+		</div>
+	{:else if scoreboard_type === 'score'}
+		<div role="cell" class="justify-self-center">
+			{row.score.score ? row.score.score : ''}
+		</div>
+	{/if}
+
+	{#each problems as problem}
+		{@const rp = row.problems?.find((p) => p.problem_id == problem.id)}
+		{#if rp}
+			{#if rp.num_judged > 0 || rp.num_pending > 0}
+				<div
+					role="cell"
+					class="flex flex-row justify-center items-center w-full h-full rounded-md"
+					style="background-color:{scoreBg(rp, problem)}">
+					{#if scoreboard_type === 'pass-fail'}
+						<div>
+							{timeToMin(rp.time)}
+							<span class="text-xs text-black/50"
+								>{rp.num_judged + rp.num_pending}</span>
+						</div>
+					{:else if scoreboard_type === 'score'}
+						<div>
+							{rp.score}
+							<span class="text-xs text-black/50"
+								>{rp.num_judged + rp.num_pending}</span>
+						</div>
+					{/if}
+				</div>
+			{:else}
+				<div role="cell"></div>
+			{/if}
+		{:else}
+			<div role="cell" class="text-center"></div>
+		{/if}
+	{/each}
+</div>

--- a/src/lib/ui/scoreboard-util.ts
+++ b/src/lib/ui/scoreboard-util.ts
@@ -1,0 +1,21 @@
+
+export function getColumns(scoreboard_type: 'pass-fail' | 'score', num_problems: number, showLogo: boolean): string {
+	let cols: string[] = ['40px'];
+	if (showLogo) {
+		cols.push('40px');
+	}
+	cols.push('425px');
+
+	if (scoreboard_type === 'pass-fail') {
+		cols.push('60px');
+		cols.push('60px');
+	} else if (scoreboard_type === 'score') {
+		cols.push('80px');
+	}
+
+	for (var i = 0; i < num_problems; i++) {
+		cols.push('1fr');
+	}
+
+	return cols.join(' ');
+}


### PR DESCRIPTION
Refactor the scoreboard into two components: scoreboard header and scoreboard row.

This doesn't change anything in the current UI, and functionally these two components will always depend on each other and have shared code. So why do this? Over time this separation would allow:
- scoreboard rows to be shown independently, e.g. on a team's page.
- individual group/region scoreboards.
- different variants of the scoreboard, e.g. paged vs scrolling, showing the same header at the bottom, or multi-column.