### PR TITLE
Add scoreboard row to team page

### DIFF
--- a/src/lib/ui/ScoreboardHeader.svelte
+++ b/src/lib/ui/ScoreboardHeader.svelte
@@ -11,7 +11,7 @@
 
 	let { scoreboard_type = 'pass-fail', problems, showLogo = true }: Props = $props();
 
-	let col = getColumns(scoreboard_type, problems?.length, showLogo);
+	let col = getColumns(scoreboard_type, problems?.length, showLogo, 'full');
 </script>
 
 <div role="rowgroup" class="sticky top-0 bg-white/90 font-semibold">

--- a/src/lib/ui/ScoreboardRow.svelte
+++ b/src/lib/ui/ScoreboardRow.svelte
@@ -12,11 +12,12 @@
 		problems: ProblemJSON[];
 		team?: TeamJSON;
 		logo?: FileReferenceJSON[];
+		mode: 'full' | 'summary';
 	}
 
-	let { scoreboard_type = 'pass-fail', problems, row, team, logo, showLogo = true }: Props = $props();
+	let { scoreboard_type = 'pass-fail', problems, row, team, logo, showLogo = true, mode = 'full' }: Props = $props();
 
-	let col = getColumns(scoreboard_type, problems?.length, showLogo);
+	let col = getColumns(scoreboard_type, problems?.length, showLogo, mode);
 
 	function scoreBg(rp: ScoreboardProblemJSON, problem: ProblemJSON):string {
 		if (rp.num_pending > 0) {
@@ -58,13 +59,15 @@
 	class="grid grid-table items-center min-h-7 even:bg-white odd:bg-gray-100 my-0.5 gap-x-0.5"
 	style="grid-template-columns: {col}">
 	<div role="cell" class="justify-self-center pr-1">{row.rank}</div>
-	{#if showLogo}
+	{#if showLogo && mode === 'full'}
 		<div role="cell" class="w-4 justify-self-center"><Logo ref={logo} /></div>
 	{/if}
+	{#if mode != 'summary'}
 	<div role="cell" class="text-nowrap overflow-hidden text-ellipsis">
 		<a href="/team/{team?.id}"
 			>{team?.display_name || team?.name}</a>
 	</div>
+	{/if}
 
 	{#if scoreboard_type === 'pass-fail'}
 		<div role="cell" class="justify-self-center text-xl">
@@ -105,7 +108,7 @@
 				<div role="cell"></div>
 			{/if}
 		{:else}
-			<div role="cell" class="text-center"></div>
+			<div role="cell" class="text-center text-sm text-gray-300">{#if mode === 'summary'}{problem.label}{/if}</div>
 		{/if}
 	{/each}
 </div>

--- a/src/lib/ui/scoreboard-util.ts
+++ b/src/lib/ui/scoreboard-util.ts
@@ -1,10 +1,11 @@
 
-export function getColumns(scoreboard_type: 'pass-fail' | 'score', num_problems: number, showLogo: boolean): string {
+export function getColumns(scoreboard_type: 'pass-fail' | 'score', num_problems: number, showLogo: boolean, mode: 'full' | 'summary'): string {
 	let cols: string[] = ['40px'];
-	if (showLogo) {
+	if (showLogo && mode === 'full') {
 		cols.push('40px');
 	}
-	cols.push('425px');
+	if (mode != 'summary')
+		cols.push('425px');
 
 	if (scoreboard_type === 'pass-fail') {
 		cols.push('60px');

--- a/src/routes/team/[id]/+layout.server.ts
+++ b/src/routes/team/[id]/+layout.server.ts
@@ -17,11 +17,21 @@ export const load = async (params) => {
 		await cc.loadOrganizations();
 	const orgs = cc.getOrganizations();
 
+	if (!cc.getProblems())
+		await cc.loadProblems();
+	const problems = cc.getProblems();
+
 	const util = new ContestUtil();
 	const logo = util.findById(orgs, team.organization_id)?.logo;
 
+	let scoreboard = await cc.loadScoreboard();
+	const row = scoreboard?.rows?.find((r) => r.team_id === team.id);
+
 	return {
 		team: team,
-		logo: logo
+		logo: logo,
+		problems: problems,
+		row: row,
+		scoreboard_type: cc.getInfo()?.scoreboard_type
 	};
 };

--- a/src/routes/team/[id]/+layout.svelte
+++ b/src/routes/team/[id]/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Logo from '$lib/ui/Logo.svelte';
+	import ScoreboardRow from '$lib/ui/ScoreboardRow.svelte';
 
 	let { data, children } = $props();
 </script>
@@ -32,6 +33,16 @@
 		<div><a href="/team/{data.team.id}/side-side">Both</a></div>
 		{/if}
 	</div>
+</div>
+
+<div class="w-full align-center border-b-[1px] border-gray-500">
+	<ScoreboardRow
+					scoreboard_type={data.scoreboard_type}
+					problems={data.problems}
+					row={data.row}
+					team={data.team}
+					logo={data.logo}
+					mode='summary'/>
 </div>
 
 <div class="overflow-auto w-full h-full">


### PR DESCRIPTION
Added a 'mode' option to the scoreboard row that shows a 'summary', which basically means 'no logo or team name'. Added this row to the top of every team page. Added a light problem label in this mode b/c it wasn't as obvious when you're not looking at the whole scoreboard.

We'll need to improve the formatting and layout later to make it look a bit prettier and easier to understand, but this fixes the gap by providing the team's current standing on every team page.

Fixes #28.