### PR TITLE
Rename contest objects

### DIFF
--- a/src/lib/contest-api.ts
+++ b/src/lib/contest-api.ts
@@ -4,50 +4,50 @@
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
 import got from 'got';
 import type {
-	AccessJSON,
-	AccountJSON,
-	AwardJSON,
-	ClarificationJSON,
-	CommentaryJSON,
-	ContestJSON,
-	ContestStateJSON,
-	FileReferenceJSON,
-	GroupJSON,
-	JudgementJSON,
-	JudgementTypeJSON,
-	LanguageJSON,
-	OrganizationJSON,
-	PersonJSON,
-	ProblemJSON,
-	RunJSON,
-	ScoreboardJSON,
-	StartStatusJSON,
-	SubmissionJSON,
-	TeamJSON
+	Access,
+	Account,
+	Award,
+	Clarification,
+	Commentary,
+	Contest,
+	ContestState,
+	FileReference,
+	Group,
+	Judgement,
+	JudgementType,
+	Language,
+	Organization,
+	Person,
+	Problem,
+	Run,
+	Scoreboard,
+	StartStatus,
+	Submission,
+	Team
 } from './contest-types';
 import { CONTEST } from './hardcoded.svelte';
 
-export class Contest {
-	info?: ContestJSON;
-	access?: AccessJSON;
-	state?: ContestStateJSON;
-	organizations?: OrganizationJSON[];
-	groups?: GroupJSON[];
-	teams?: TeamJSON[];
-	persons?: PersonJSON[];
-	accounts?: AccountJSON[];
-	account?: AccountJSON;
-	languages?: LanguageJSON[];
-	judgementTypes?: JudgementTypeJSON[];
-	problems?: ProblemJSON[];
-	submissions?: SubmissionJSON[];
-	judgements?: JudgementJSON[];
-	runs?: RunJSON[];
-	clarifications?: ClarificationJSON[];
-	commentary?: CommentaryJSON[];
-	awards?: AwardJSON[];
-	startStatus?: StartStatusJSON[];
-	scoreboard?: ScoreboardJSON;
+export class ContestAPI {
+	contest?: Contest;
+	access?: Access;
+	state?: ContestState;
+	organizations?: Organization[];
+	groups?: Group[];
+	teams?: Team[];
+	persons?: Person[];
+	accounts?: Account[];
+	account?: Account;
+	languages?: Language[];
+	judgementTypes?: JudgementType[];
+	problems?: Problem[];
+	submissions?: Submission[];
+	judgements?: Judgement[];
+	runs?: Run[];
+	clarifications?: Clarification[];
+	commentary?: Commentary[];
+	awards?: Award[];
+	startStatus?: StartStatus[];
+	scoreboard?: Scoreboard;
 
 	contestURL: string;
 
@@ -142,9 +142,9 @@ export class Contest {
 		});*/
 	}
 
-	async loadInfo(force?: boolean): Promise<void> {
-		if (force || !this.info)
-			this.info = await this.loadObject('');
+	async loadContest(force?: boolean): Promise<void> {
+		if (force || !this.contest)
+			this.contest = await this.loadObject('');
 	}
 
 	async loadAccess(force?: boolean): Promise<void> {
@@ -174,7 +174,7 @@ export class Contest {
 
 	async loadProblems(force?: boolean): Promise<void> {
 		if (force || !this.problems) {
-			const problems2: ProblemJSON[] = await this.loadObject('problems');
+			const problems2: Problem[] = await this.loadObject('problems');
 			problems2.sort((a, b) => (a.ordinal > b.ordinal ? 1 : b.ordinal > a.ordinal ? -1 : 0));
 			this.problems = problems2;
 		}
@@ -192,7 +192,7 @@ export class Contest {
 
 	async loadTeams(force?: boolean): Promise<void> {
 		if (force || !this.teams) {
-			const teams2: TeamJSON[] = await this.loadObject('teams');
+			const teams2: Team[] = await this.loadObject('teams');
 			// sort by team id
 			teams2.sort((a, b) => {
 				// try parsing as number first
@@ -250,7 +250,7 @@ export class Contest {
 
 	async loadScoreboard(force?: boolean): Promise<void> {
 		if (force || !this.scoreboard) {
-			const scoreboard2: ScoreboardJSON = await this.loadObject('scoreboard');
+			const scoreboard2: Scoreboard = await this.loadObject('scoreboard');
 			scoreboard2.rows.sort((a, b) => {
 				return a.rank - b.rank;
 			});
@@ -267,64 +267,64 @@ export class Contest {
 	getContestURL(): string {
 		return this.contestURL;
 	}
-	getInfo(): ContestJSON | undefined {
-		return this.info;
+	getContest(): Contest | undefined {
+		return this.contest;
 	}
 	getAccess() {
 		return this.access;
 	}
-	getState(): ContestStateJSON | undefined {
+	getState(): ContestState | undefined {
 		return this.state;
 	}
 	getStartStatus() {
 		return this.startStatus;
 	}
-	getLanguages(): LanguageJSON[] {
+	getLanguages(): Language[] {
 		return this.languages || [];
 	}
-	getJudgementTypes(): JudgementTypeJSON[] {
+	getJudgementTypes(): JudgementType[] {
 		return this.judgementTypes || [];
 	}
-	getProblems(): ProblemJSON[] {
+	getProblems(): Problem[] {
 		return this.problems || [];
 	}
-	getGroups(): GroupJSON[] {
+	getGroups(): Group[] {
 		return this.groups || [];
 	}
-	getTeams(): TeamJSON[] {
+	getTeams(): Team[] {
 		return this.teams || [];
 	}
-	getOrganizations(): OrganizationJSON[] {
+	getOrganizations(): Organization[] {
 		return this.organizations || [];
 	}
-	getPersons(): PersonJSON[] {
+	getPersons(): Person[] {
 		return this.persons || [];
 	}
-	getAccounts(): AccountJSON[] {
+	getAccounts(): Account[] {
 		return this.accounts || [];
 	}
-	getAccount(): AccountJSON | undefined {
+	getAccount(): Account | undefined {
 		return this.account;
 	}
-	getSubmissions(): SubmissionJSON[] {
+	getSubmissions(): Submission[] {
 		return this.submissions || [];
 	}
-	getJudgements(): JudgementJSON[] {
+	getJudgements(): Judgement[] {
 		return this.judgements || [];
 	}
-	getRuns(): RunJSON[] {
+	getRuns(): Run[] {
 		return this.runs || [];
 	}
-	getClarifications(): ClarificationJSON[] {
+	getClarifications(): Clarification[] {
 		return this.clarifications || [];
 	}
-	getCommentary(): CommentaryJSON[] {
+	getCommentary(): Commentary[] {
 		return this.commentary || [];
 	}
-	getScoreboard(): ScoreboardJSON | undefined {
+	getScoreboard(): Scoreboard | undefined {
 		return this.scoreboard;
 	}
-	getAwards(): AwardJSON[] {
+	getAwards(): Award[] {
 		return this.awards || [];
 	}
 
@@ -337,7 +337,7 @@ export class Contest {
 		return total / this.timeDelta.length;
 	}
 
-	resolveURL(ref: FileReferenceJSON | undefined): string | undefined {
+	resolveURL(ref: FileReference | undefined): string | undefined {
 		if (!ref || !ref.href) return undefined;
 		// If href is already absolute, return as-is
 		if (ref.href.startsWith('http://') || ref.href.startsWith('https://')) {
@@ -347,7 +347,7 @@ export class Contest {
 		return this.contestURL.substring(0, CONTEST.url.length) + ref.href;
 	}
 
-	private isFileReference(obj: any): obj is FileReferenceJSON {
+	private isFileReference(obj: any): obj is FileReference {
 		if (!(typeof obj === 'object' && 'href' in obj && 'mime' in obj))
 			return false;
 		return true;

--- a/src/lib/contest-time-util.ts
+++ b/src/lib/contest-time-util.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright later.
  */
-import type { ContestJSON, RelTime } from './contest-types';
+import type { Contest, RelTime } from './contest-types';
 
 function isNumber(value: any): value is number {
 	return typeof value === 'number';
@@ -64,7 +64,7 @@ function formatTimeInMin(timeMs: number | undefined) {
 	return sb.join("");
 }
 
-export function getContestState(contest: ContestJSON | undefined): 'unscheduled' | 'countdown' | 'paused' | 'running' | 'frozen' | 'finished' {
+export function getContestState(contest: Contest | undefined): 'unscheduled' | 'countdown' | 'paused' | 'running' | 'frozen' | 'finished' {
 	if (contest == null) {
 		return 'unscheduled';
 	}
@@ -98,7 +98,7 @@ export function getContestState(contest: ContestJSON | undefined): 'unscheduled'
 	return 'running';
 }
 
-export function getContestTime(contest: ContestJSON | undefined, short: boolean): string | undefined {
+export function getContestTime(contest: Contest | undefined, short: boolean): string | undefined {
 	if (contest == null) {
 		return undefined;
 	}

--- a/src/lib/contest-types.ts
+++ b/src/lib/contest-types.ts
@@ -8,12 +8,12 @@ export type RelTime = string;
 
 export type Time = string;
 
-export interface ContestLocationJSON {
+export interface ContestLocation {
 	latitude: number;
 	longitude: number;
 }
 
-export interface ContestJSON {
+export interface Contest {
 	id: Id;
 	name: string;
 	formal_name?: string;
@@ -23,13 +23,13 @@ export interface ContestJSON {
 	scoreboard_type: 'pass-fail' | 'score';
 	penalty_time?: number | RelTime; // 2023-06 | draft
 	countdown_pause_time?: RelTime;
-	banner?: FileReferenceJSON[];
-	logo?: FileReferenceJSON[];
-	location?: ContestLocationJSON;
+	banner?: FileReference[];
+	logo?: FileReference[];
+	location?: ContestLocation;
 	time_multiplier?: number;
 }
 
-export interface FileReferenceJSON {
+export interface FileReference {
 	href: string;
 	filename: string;
 	mime: string;
@@ -38,7 +38,7 @@ export interface FileReferenceJSON {
 	height?: number;
 }
 
-export interface ContestStateJSON {
+export interface ContestState {
 	started?: Time;
 	frozen?: Time;
 	ended?: Time;
@@ -48,28 +48,28 @@ export interface ContestStateJSON {
 }
 
 
-export interface TeamLocationJSON {
+export interface TeamLocation {
 	x: number;
 	y: number;
 	rotation: number;
 }
 
-export interface TeamJSON {
+export interface Team {
 	id: Id;
 	label: string;
 	name: string;
 	display_name: string;
 	organization_id: string;
 	group_ids?: string[];
-	photo?: FileReferenceJSON[];
-	video?: FileReferenceJSON[];
-	desktop?: FileReferenceJSON[];
-	webcam?: FileReferenceJSON[];
-	audio?: FileReferenceJSON[];
-	location: TeamLocationJSON;
+	photo?: FileReference[];
+	video?: FileReference[];
+	desktop?: FileReference[];
+	webcam?: FileReference[];
+	audio?: FileReference[];
+	location: TeamLocation;
 }
 
-export interface ProblemJSON {
+export interface Problem {
 	id: Id;
 	uuid?: string;
 	label: string;
@@ -78,49 +78,49 @@ export interface ProblemJSON {
 	rgb?: string;
 	color?: string;
     max_score?: number;
-	statement: FileReferenceJSON[];
+	statement: FileReference[];
 }
 
-export interface GroupJSON {
+export interface Group {
 	id: Id;
 	name: string;
 	type?: string;
 }
 
-export interface OrganizationJSON {
+export interface Organization {
 	id: Id;
 	name: string;
 	formal_name?: string;
 	country?: string;
 	twitter_hashtag?: string;
 	url?: string;
-	logo?: FileReferenceJSON[];
+	logo?: FileReference[];
 }
 
-export interface SubmissionJSON {
+export interface Submission {
 	id: Id;
 	language_id: Id;
 	problem_id: Id;
 	team_id: Id;
 	time: Time;
 	contest_time: RelTime;
-	files: FileReferenceJSON[];
-	reaction?: FileReferenceJSON[];
+	files: FileReference[];
+	reaction?: FileReference[];
 }
 
-export interface JudgementTypeJSON {
+export interface JudgementType {
 	id: Id;
 	name: string;
 	penalty: boolean;
 	solved: boolean;
 }
 
-export interface LanguageJSON {
+export interface Language {
 	id: Id;
 	name: string;
 }
 
-export interface PersonJSON {
+export interface Person {
 	id: Id;
 	name: string;
 	team_ids?: Id[];
@@ -128,31 +128,31 @@ export interface PersonJSON {
 	email?: string;
 	sex?: string;
 	role: 'contestant' | 'coach' | 'staff' | 'other';
-	photo?: FileReferenceJSON[];
+	photo?: FileReference[];
 }
 
-export interface ScoreboardJSON {
+export interface Scoreboard {
 	time: Time;
 	contest_time: RelTime;
-	state: ContestStateJSON;
-	rows: ScoreboardRowJSON[];
+	state: ContestState;
+	rows: ScoreboardRow[];
 }
 
-export interface ScoreboardScoreJSON {
+export interface ScoreboardScore {
 	num_solved?: number;
 	total_time?: number | RelTime; // 2023-06 | draft
 	score?: number;
 	time?: RelTime;
 }
 
-export interface ScoreboardRowJSON {
+export interface ScoreboardRow {
 	rank: number;
 	team_id: Id;
-	score: ScoreboardScoreJSON;
-	problems?: ScoreboardProblemJSON[];
+	score: ScoreboardScore;
+	problems?: ScoreboardProblem[];
 }
 
-export interface ScoreboardProblemJSON {
+export interface ScoreboardProblem {
 	problem_id: Id;
 	num_judged: number;
 	num_pending: number;
@@ -161,7 +161,7 @@ export interface ScoreboardProblemJSON {
 	time?: number | RelTime; // 2023-06 | draft
 }
 
-export interface JudgementJSON {
+export interface Judgement {
 	id: Id;
 	submission_id: Id;
 	judgement_type_id: Id;
@@ -174,19 +174,19 @@ export interface JudgementJSON {
 	max_run_time: number;
 }
 
-export interface AwardJSON {
+export interface Award {
 	id: Id; // todo
 }
 
-export interface RunJSON {
+export interface Run {
 	id: Id; // todo
 }
 
-export interface AccountJSON {
+export interface Account {
 	id: Id; // todo
 }
 
-export interface ClarificationJSON {
+export interface Clarification {
 	id: Id;
 	from_team_id?: Id;
 	to_team_ids?: Id[];
@@ -198,14 +198,14 @@ export interface ClarificationJSON {
 	contest_time: RelTime;
 }
 
-export interface CommentaryJSON {
+export interface Commentary {
 	id: Id; // todo
 }
 
-export interface AccessJSON {
+export interface Access {
 	id: Id; // todo
 }
 
-export interface StartStatusJSON {
+export interface StartStatus {
 	id: Id; // todo
 }

--- a/src/lib/contest-util.ts
+++ b/src/lib/contest-util.ts
@@ -1,9 +1,9 @@
 /**
  * Copyright later.
  */
-import type { Contest } from './contest';
+import type { ContestAPI } from './contest-api';
 import { parseRelTime } from './contest-time-util';
-import type { FileReferenceJSON, ProblemJSON, SubmissionJSON } from './contest-types';
+import type { FileReference, Problem, Submission } from './contest-types';
 
 export class ContestUtil {
 	findById<Type extends { id: string }>(arr: Array<Type> | undefined, id: string | undefined): Type | undefined {
@@ -50,9 +50,9 @@ export class ContestUtil {
 	}
 
 	bestSquareLogo(
-		logos: FileReferenceJSON[] | undefined,
+		logos: FileReference[] | undefined,
 		size: number
-	): FileReferenceJSON | undefined {
+	): FileReference | undefined {
 		if (!logos || logos.length == 0 || size < 1) {
 			return undefined;
 		}
@@ -67,7 +67,7 @@ export class ContestUtil {
 				return logo;
 		}
 
-		let best: FileReferenceJSON | undefined;
+		let best: FileReference | undefined;
 		for (var i = 0; i < logos.length; i++) {
 			let ref = logos[i];
 			if (ref.width != ref.height) {
@@ -97,10 +97,10 @@ export class ContestUtil {
 	}
 
 	bestLogo(
-		logos: FileReferenceJSON[] | undefined,
+		logos: FileReference[] | undefined,
 		width: number,
 		height: number
-	): FileReferenceJSON | undefined {
+	): FileReference | undefined {
 		if (!logos || logos.length == 0 || width < 1 || height < 1) {
 			return undefined;
 		}
@@ -115,7 +115,7 @@ export class ContestUtil {
 				return logo;
 		}
 
-		let best: FileReferenceJSON | undefined;
+		let best: FileReference | undefined;
 		for (var i = 0; i < logos.length; i++) {
 			let ref = logos[i];
 			if (best == null) {
@@ -141,7 +141,7 @@ export class ContestUtil {
 		return best;
 	}
 
-	isFirstToSolve(contest: Contest, submission: SubmissionJSON): boolean {
+	isFirstToSolve(contest: ContestAPI, submission: Submission): boolean {
 		const problem_id = submission.problem_id;
 		const submissions = contest.getSubmissions();
 		if (!submissions) {
@@ -170,7 +170,7 @@ export class ContestUtil {
 		return false;
 	}
 
-	sortProblems(problems: ProblemJSON[]): any {
+	sortProblems(problems: Problem[]): any {
 		return problems.sort((a, b) => (a.ordinal > b.ordinal ? 1 : b.ordinal > a.ordinal ? -1 : 0));
 	}
 }

--- a/src/lib/contests.ts
+++ b/src/lib/contests.ts
@@ -3,12 +3,12 @@
  */
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
 import got from 'got';
-import type { ContestJSON } from './contest-types';
-import { Contest } from './contest';
+import type { Contest } from './contest-types';
+import { ContestAPI } from './contest-api';
 import { CONTEST } from './hardcoded.svelte';
 
 export class Contests {
-	contests: ContestJSON[] | undefined;
+	contests: Contest[] | undefined;
 	contestObjs: Contest[] | undefined;
 	baseURL: string;
 
@@ -22,7 +22,7 @@ export class Contests {
 		const startTime = performance.now();
 		try {
 			const response = await got.get(this.baseURL + 'contests', this.getHttpOptions());
-			this.contests = JSON.parse(response.body) as ContestJSON[];
+			this.contests = JSON.parse(response.body) as Contest[];
 			const endTime = performance.now();
 			console.log(`Fetched ${this.baseURL} in ${endTime - startTime}ms`);
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -66,11 +66,11 @@ export class Contests {
 		return this.baseURL;
 	}
 
-	getContests(): ContestJSON[] | undefined {
+	getContests(): Contest[] | undefined {
 		return this.contests;
 	}
 
-	getContest(): Contest | undefined {
+	getContest(): ContestAPI | undefined {
 		if (!this.contests || this.contests.length === 0) {
 			return undefined;
 		}
@@ -82,7 +82,7 @@ export class Contests {
 		} else {
 			contestURL += this.contests[0].id;
 		}
-		const c: Contest = new Contest(contestURL);
+		const c: ContestAPI = new ContestAPI(contestURL);
 		return c;
 	}
 

--- a/src/lib/ui/Banner.svelte
+++ b/src/lib/ui/Banner.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { FileReferenceJSON } from '$lib/contest-types';
+	import type { FileReference } from '$lib/contest-types';
 	import Image from './Image.svelte';
 
 	interface Props {
-		ref?: FileReferenceJSON[];
+		ref?: FileReference[];
 		size?: 16 | 24 | 32 | 64;
 	}
 

--- a/src/lib/ui/Clock.svelte
+++ b/src/lib/ui/Clock.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { getContestTime, getContestState } from '$lib/contest-time-util';
-	import type { ContestJSON } from '$lib/contest-types';
+	import type { Contest } from '$lib/contest-types';
 	import { onMount } from 'svelte';
 
 	interface Props {
-		contest?: ContestJSON;
+		contest?: Contest;
 	}
 
 	let { contest }: Props = $props();

--- a/src/lib/ui/Image.svelte
+++ b/src/lib/ui/Image.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { FileReferenceJSON } from '$lib/contest-types';
+	import type { FileReference } from '$lib/contest-types';
 	import { ContestUtil } from '../contest-util';
 
 	interface Props {
-		ref?: FileReferenceJSON[];
+		ref?: FileReference[];
 		size: number;
 	}
 

--- a/src/lib/ui/JudgementType.svelte
+++ b/src/lib/ui/JudgementType.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import type { JudgementTypeJSON } from '$lib/contest-types';
+	import type { JudgementType } from '$lib/contest-types';
 
 	interface Props {
-		judgement_type?: JudgementTypeJSON;
+		judgement_type?: JudgementType;
 	}
 
 	let { judgement_type }: Props = $props();

--- a/src/lib/ui/Logo.svelte
+++ b/src/lib/ui/Logo.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { FileReferenceJSON } from '$lib/contest-types';
+	import type { FileReference } from '$lib/contest-types';
 	import Image from './Image.svelte';
 
 	interface Props {
-		ref?: FileReferenceJSON[];
+		ref?: FileReference[];
 		size?: number;
 	}
 

--- a/src/lib/ui/Person.svelte
+++ b/src/lib/ui/Person.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { PersonJSON } from '$lib/contest-types';
+	import type { Person } from '$lib/contest-types';
 	import Image from './Image.svelte';
 
 	interface Props {
-		person: PersonJSON;
+		person: Person;
 	}
 
 	let { person }: Props = $props();

--- a/src/lib/ui/Photo.svelte
+++ b/src/lib/ui/Photo.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { FileReferenceJSON } from '$lib/contest-types';
+	import type { FileReference } from '$lib/contest-types';
 	import Image from './Image.svelte';
 
 	interface Props {
-		ref?: FileReferenceJSON[];
+		ref?: FileReference[];
 		size?: number;
 	}
 

--- a/src/lib/ui/Problem.svelte
+++ b/src/lib/ui/Problem.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { parseHexColor, darker, rgbToHex } from '$lib/color-util.js';
-	import type { ProblemJSON } from '$lib/contest-types';
+	import type { Problem } from '$lib/contest-types';
 
 	interface Props {
-		problem?: ProblemJSON;
+		problem?: Problem;
 	}
 
 	let { problem }: Props = $props();

--- a/src/lib/ui/ScoreboardHeader.svelte
+++ b/src/lib/ui/ScoreboardHeader.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import type { ProblemJSON } from '$lib/contest-types.js';
+	import type { Problem as ProblemObj } from '$lib/contest-types.js';
 	import Problem from './Problem.svelte';
 	import { getColumns } from './scoreboard-util';
 
 	interface Props {
 		showLogo?: boolean;
 		scoreboard_type?: 'pass-fail' | 'score';
-		problems: ProblemJSON[];
+		problems: ProblemObj[];
 	}
 
 	let { scoreboard_type = 'pass-fail', problems, showLogo = true }: Props = $props();

--- a/src/lib/ui/ScoreboardRow.svelte
+++ b/src/lib/ui/ScoreboardRow.svelte
@@ -2,16 +2,16 @@
 	import Logo from './Logo.svelte';
 	import { parseHexColor, rgbToHex, FAILED, SOLVED, PENDING, SCORING_MID } from '$lib/color-util.js';
 	import { timeToMin } from '$lib/contest-time-util.js';
-	import type { FileReferenceJSON, ProblemJSON, ScoreboardProblemJSON, ScoreboardRowJSON, TeamJSON } from '$lib/contest-types.js';
+	import type { FileReference, Problem, ScoreboardProblem, ScoreboardRow, Team } from '$lib/contest-types.js';
 	import { getColumns } from './scoreboard-util';
 
 	interface Props {
 		showLogo?: boolean;
 		scoreboard_type?: 'pass-fail' | 'score';
-		row: ScoreboardRowJSON;
-		problems: ProblemJSON[];
-		team?: TeamJSON;
-		logo?: FileReferenceJSON[];
+		row: ScoreboardRow;
+		problems: Problem[];
+		team?: Team;
+		logo?: FileReference[];
 		mode: 'full' | 'summary';
 	}
 
@@ -19,7 +19,7 @@
 
 	let col = getColumns(scoreboard_type, problems?.length, showLogo, mode);
 
-	function scoreBg(rp: ScoreboardProblemJSON, problem: ProblemJSON):string {
+	function scoreBg(rp: ScoreboardProblem, problem: Problem):string {
 		if (rp.num_pending > 0) {
 			return PENDING;
 		}

--- a/src/lib/ui/Video.svelte
+++ b/src/lib/ui/Video.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { FileReferenceJSON } from '$lib/contest-types';
+	import type { FileReference } from '$lib/contest-types';
 
 	import { onMount, onDestroy } from 'svelte';
 	import videojs from 'video.js';
@@ -7,7 +7,7 @@
 	import 'video.js/dist/video-js.css'; // default Video.js CSS
 
 	interface Props {
-		ref?: FileReferenceJSON[];
+		ref?: FileReference[];
 		type: string;
 	}
 

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -5,15 +5,15 @@ export const load = async (_params) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	if (!cc.getInfo())
-		await cc.loadInfo();
-	const info = cc.getInfo();
-	if (!info) throw error(404);
+	await Promise.all([cc.loadContest()]);
+
+	const contest = cc.getContest();
+	if (!contest) throw error(404);
 
 	return {
-		contest: info,
-		name: info.formal_name || info.name,
-		banner: info.banner,
-		logo: info.logo,
+		contest: contest,
+		name: contest.formal_name || contest.name,
+		banner: contest.banner,
+		logo: contest.logo,
 	};
 };

--- a/src/routes/problem/[id]/+page.server.ts
+++ b/src/routes/problem/[id]/+page.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { loadContest } from '$lib/state.svelte.js';
 import { timeToMin } from '$lib/contest-time-util';
-import type { JudgementJSON, JudgementTypeJSON } from '$lib/contest-types';
+import type { Judgement, JudgementType } from '$lib/contest-types';
 import { ContestUtil } from '$lib/contest-util';
 
 export const load = async (params) => {
@@ -30,7 +30,7 @@ export const load = async (params) => {
 	const util = new ContestUtil();
 	const submissionData = submissions?.map((s)=> {
 		const jud = util.findManyBySubmissionId(judgements, s.id);
-		let j: JudgementJSON | undefined;
+		let j: Judgement | undefined;
 		if (jud && jud.length > 0) {
 			// find current judgement
 			j = jud.find(jj => jj.current);
@@ -41,7 +41,7 @@ export const load = async (params) => {
 		}
 		
 		let judge = '';
-		let jt: JudgementTypeJSON | undefined;
+		let jt: JudgementType | undefined;
 		if (j) {
 			jt = util.findById(judgementTypes, j.judgement_type_id);
 			if (j.score != undefined)

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import JudgementType from '$lib/ui/JudgementType.svelte';
-import Problem from '$lib/ui/Problem.svelte';
+	import Problem from '$lib/ui/Problem.svelte';
 
 	let { data } = $props();
 </script>

--- a/src/routes/scoreboard/+page.server.ts
+++ b/src/routes/scoreboard/+page.server.ts
@@ -6,10 +6,10 @@ export const load = async (_params) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([cc.loadInfo(), cc.loadTeams(), cc.loadOrganizations(), cc.loadProblems(), cc.loadScoreboard()]);
+	await Promise.all([cc.loadContest(), cc.loadTeams(), cc.loadOrganizations(), cc.loadProblems(), cc.loadScoreboard()]);
 
-	let info = cc.getInfo();
-	if (!info) throw error(404);
+	let contest = cc.getContest();
+	if (!contest) throw error(404);
 
 	let scoreboard = cc.getScoreboard();
 	if (!scoreboard) throw error(404);
@@ -28,8 +28,8 @@ export const load = async (_params) => {
 	const hasLogos = logos.filter(x => x).length > 0;
 
 	return {
-		name: info.name,
-		scoreboard_type: info.scoreboard_type,
+		name: contest.name,
+		scoreboard_type: contest.scoreboard_type,
 		scoreboard: scoreboard,
 		teams: sortedTeams,
 		logos: logos,

--- a/src/routes/team/[id]/+layout.server.ts
+++ b/src/routes/team/[id]/+layout.server.ts
@@ -6,7 +6,7 @@ export const load = async (params) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([cc.loadTeams(), cc.loadOrganizations()]);
+	await Promise.all([cc.loadContest(), cc.loadTeams(), cc.loadOrganizations(), cc.loadProblems(), cc.loadScoreboard()]);
 
 	const teams = cc.getTeams();
 	const team = teams?.find((t) => t.id && t.id === params.params.id);
@@ -14,14 +14,12 @@ export const load = async (params) => {
 
 	const orgs = cc.getOrganizations();
 
-	if (!cc.getProblems())
-		await cc.loadProblems();
 	const problems = cc.getProblems();
 
 	const util = new ContestUtil();
 	const logo = util.findById(orgs, team.organization_id)?.logo;
 
-	let scoreboard = await cc.loadScoreboard();
+	let scoreboard = cc.getScoreboard();
 	const row = scoreboard?.rows?.find((r) => r.team_id === team.id);
 
 	return {
@@ -29,6 +27,6 @@ export const load = async (params) => {
 		logo: logo,
 		problems: problems,
 		row: row,
-		scoreboard_type: cc.getInfo()?.scoreboard_type
+		scoreboard_type: cc.getContest()?.scoreboard_type
 	};
 };

--- a/src/routes/team/[id]/+page.server.ts
+++ b/src/routes/team/[id]/+page.server.ts
@@ -2,7 +2,7 @@ import { error } from '@sveltejs/kit';
 import { ContestUtil } from '$lib/contest-util';
 import { loadContest } from '$lib/state.svelte.js';
 import { timeToMin } from '$lib/contest-time-util.js';
-import type { JudgementJSON, JudgementTypeJSON } from '$lib/contest-types.js';
+import type { Judgement, JudgementType } from '$lib/contest-types.js';
 import * as countries from 'i18n-iso-countries';
 import en from 'i18n-iso-countries/langs/en.json';
 
@@ -48,7 +48,7 @@ export const load = async (params) => {
 	
 	const submissionData = submissions?.map((s)=> {
 		const jud = util.findManyBySubmissionId(judgements, s.id);
-		let j: JudgementJSON | undefined;
+		let j: Judgement | undefined;
 		if (jud && jud.length > 0) {
 			// find current judgement
 			j = jud.find(jj => jj.current);
@@ -59,7 +59,7 @@ export const load = async (params) => {
 		}
 		
 		let judge = '';
-		let jt: JudgementTypeJSON | undefined;
+		let jt: JudgementType | undefined;
 		if (j) {
 			jt = util.findById(judgementTypes, j.judgement_type_id);
 			if (j.score != undefined)


### PR DESCRIPTION
I initially named all the contest API types as 'xJSON' because they were JSON types from the Contest API. In reality though it's unimportant what format they are typically loaded from, they are just regular typescript objects and the naming pattern is verbose and annoying.

Before we go too much farther, this just renames all the types to remove the 'JSON'. The Contest object had to be renamed to ContestAPI to avoid overlap. The result is slightly more readable and shorter code.