### PR TITLE
Fix layout and resizing issues

### DIFF
--- a/src/lib/ui/Video.svelte
+++ b/src/lib/ui/Video.svelte
@@ -23,7 +23,7 @@
 		autoplay: true,
 		controls: false,
 		responsive: true,
-		fluid: true,
+		fluid: false,
 		poster: '/images/icpc-logo.png',
 		preload: 'auto',
 		mpegtsjs: {
@@ -63,7 +63,7 @@
 
 {#if src}
 	<!-- svelte-ignore a11y_media_has_caption -->
-	<video bind:this={videoNode} class="video-js vjs-default-skin"></video>
+	<video bind:this={videoNode} class="video-js vjs-default-skin w-full h-full"></video>
 {:else}
 	<span class="self-center">({type} unavailable)</span>
 {/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,7 +8,7 @@
 	let { data, children } = $props();
 </script>
 
-<div class="w-screen h-screen overflow-hidden flex flex-col">
+<div class="flex flex-col w-screen h-screen max-w-screen max-h-screen">
 	<div class="flex flex-row gap-8 bg-gray-800 text-white p-4 items-center">
 		{#if data.logo && data.logo.length > 0}
 			<div class="w-12">
@@ -23,13 +23,13 @@
 		<div class="text-lg"><a href="/scoreboard">Scoreboard</a></div>
 	</div>
 
-	<div class="overflow-auto flex flex-col gap-2 w-full h-full">
+	<div class="gap-2 w-full grow overflow-hidden">
 		{@render children()}
-
-		{#if data.banner && data.banner.length > 0}
-			<div class="self-center p-2">
-				<Banner ref={data.banner} />
-			</div>
-		{/if}
 	</div>
+
+	{#if data.banner && data.banner.length > 0}
+		<div class="self-center p-2">
+			<Banner ref={data.banner} />
+		</div>
+	{/if}
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
 	let { data } = $props();
 </script>
 
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 w-full gap-2 p-2">
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 w-full h-full gap-2 p-2 overflow-auto">
 	{#each data.teams as team, i}
 		<div class="flex flex-row items-center bg-gray-200 rounded-md">
 			<a href="/team/{team.id}">

--- a/src/routes/scoreboard/+page.svelte
+++ b/src/routes/scoreboard/+page.svelte
@@ -18,7 +18,7 @@
 	});
 </script>
 
-<div class="w-full text-sm p-2" role="table" aria-label="scoreboard">
+<div class="w-full h-full overflow-auto text-sm p-2" role="table" aria-label="scoreboard">
 	<ScoreboardHeader hasLogos={data.hasLogos} scoreboard_type={data.scoreboard_type} problems={data.problems} />
 
 	<div role="rowgroup">

--- a/src/routes/team/[id]/+layout.svelte
+++ b/src/routes/team/[id]/+layout.svelte
@@ -5,7 +5,7 @@
 	let { data, children } = $props();
 </script>
 
-<div class="w-full h-full overflow-hidden flex flex-col">
+<div class="w-full h-full max-w-full max-h-full overflow-hidden flex flex-col">
 	<div class="flex flex-row gap-4 bg-gray-700 text-white px-4 py-2 items-center">
 		{#if data.logo}
 			<div class="w-16 h-16">
@@ -47,7 +47,7 @@
 			mode="summary" />
 	</div>
 
-	<div class="overflow-auto w-full h-full">
+	<div class="gap-2 w-full grow overflow-hidden">
 		{@render children()}
 	</div>
 </div>

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -7,7 +7,7 @@
 	let { data } = $props();
 </script>
 
-<div class="flex flex-col p-2 gap-1">
+<div class="flex flex-col p-2 gap-1 h-full overflow-auto">
 	<div class="flex flex-col">
 		<div class="text-xl">Name</div>
 		<div>{data.team.name}</div>

--- a/src/routes/team/[id]/desktop/+page.svelte
+++ b/src/routes/team/[id]/desktop/+page.svelte
@@ -4,6 +4,4 @@
 	let { data } = $props();
 </script>
 
-<div class="w-full h-full">
-	<Video ref={data.team.desktop} type="desktop" />
-</div>
+<Video ref={data.team.desktop} type="desktop" />

--- a/src/routes/team/[id]/pip/+page.svelte
+++ b/src/routes/team/[id]/pip/+page.svelte
@@ -4,12 +4,10 @@
 	let { data } = $props();
 </script>
 
-<div class="flex flex-row relative">
-	<div class="w-full h-full">
-		<Video ref={data.team.desktop} type="desktop" />
+<div class="w-full h-full relative">
+	<Video ref={data.team.desktop} type="desktop" />
 
-		<div class="w-84 h-56 absolute top-8 right-0">
-			<Video ref={data.team.webcam} type="webcam" />
-		</div>
+	<div class="w-84 aspect-video absolute top-8 right-0">
+		<Video ref={data.team.webcam} type="webcam" />
 	</div>
 </div>

--- a/src/routes/team/[id]/rpip/+page.svelte
+++ b/src/routes/team/[id]/rpip/+page.svelte
@@ -4,12 +4,10 @@
 	let { data } = $props();
 </script>
 
-<div class="flex flex-row relative">
-	<div class="w-full h-full">
-		<Video ref={data.team.webcam} type="webcam" />
+<div class="w-full h-full relative">
+	<Video ref={data.team.webcam} type="webcam" />
 
-		<div class="w-84 h-56 absolute top-8 right-0">
-			<Video ref={data.team.desktop} type="desktop" />
-		</div>
+	<div class="w-84 aspect-video absolute top-8 right-0">
+		<Video ref={data.team.desktop} type="desktop" />
 	</div>
 </div>

--- a/src/routes/team/[id]/side-side/+page.svelte
+++ b/src/routes/team/[id]/side-side/+page.svelte
@@ -5,10 +5,6 @@
 </script>
 
 <div class="flex flex-row justify-items-stretch w-full h-full">
-	<div class="w-full h-full">
-		<Video ref={data.team.desktop} type="desktop" />
-	</div>
-	<div class="w-full h-full">
-		<Video ref={data.team.webcam} type="webcam" />
-	</div>
+	<Video ref={data.team.desktop} type="desktop" />
+	<Video ref={data.team.webcam} type="webcam" />
 </div>

--- a/src/routes/team/[id]/webcam/+page.svelte
+++ b/src/routes/team/[id]/webcam/+page.svelte
@@ -4,6 +4,4 @@
 	let { data } = $props();
 </script>
 
-<div class="w-full h-full">
-	<Video ref={data.team.webcam} type="webcam" />
-</div>
+<Video ref={data.team.webcam} type="webcam" />


### PR DESCRIPTION
Fix the layout so that the banner is always across the bottom of the screen and each page decides if it should fill the remaining content area, scroll, or not.

Homepage, team info page, and scoreboard are set to add scrollbars as necessary. 'Fluid' disabled for Video so that it doesn't overflow. All video set to fit within the current screen size with black edges as necessary to fill.

Fixes #30.