### PR TITLE
Team area map

### DIFF
--- a/src/lib/contest-api.ts
+++ b/src/lib/contest-api.ts
@@ -16,6 +16,7 @@ import type {
 	Judgement,
 	JudgementType,
 	Language,
+	MapInfo,
 	Organization,
 	Person,
 	Problem,
@@ -48,6 +49,7 @@ export class ContestAPI {
 	awards?: Award[];
 	startStatus?: StartStatus[];
 	scoreboard?: Scoreboard;
+	mapInfo?: MapInfo;
 
 	contestURL: string;
 
@@ -281,6 +283,12 @@ export class ContestAPI {
 		}
 	}
 
+	async loadMapInfo(force?: boolean): Promise<void> {
+		if (force || !this.mapInfo) {
+			this.mapInfo = await this.loadObject('map-info');
+		}
+	}
+
 	getContestURL(): string {
 		return this.contestURL;
 	}
@@ -343,6 +351,9 @@ export class ContestAPI {
 	}
 	getAwards(): Award[] {
 		return this.awards || [];
+	}
+	getMapInfo(): MapInfo | undefined {
+		return this.mapInfo;
 	}
 
 	getTimeDelta() {

--- a/src/lib/contest-types.ts
+++ b/src/lib/contest-types.ts
@@ -47,6 +47,13 @@ export interface ContestState {
 	end_of_updates?: Time;
 }
 
+export interface MapInfo {
+	table_width: number;
+	table_depth: number;
+	table_area_width: number;
+	table_area_depth: number;
+}
+
 export interface TeamLocation {
 	x: number;
 	y: number;
@@ -65,7 +72,7 @@ export interface Team {
 	desktop?: FileReference[];
 	webcam?: FileReference[];
 	audio?: FileReference[];
-	location: TeamLocation;
+	location?: TeamLocation;
 }
 
 export interface Problem {

--- a/src/lib/ui/FloorMap.svelte
+++ b/src/lib/ui/FloorMap.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import type { MapInfo, Team } from '$lib/contest-types';
+
+	interface Props {
+		mapInfo?: MapInfo;
+		teams: Team[];
+		selected?: string;
+	}
+
+	let { mapInfo, teams, selected = $bindable() }: Props = $props();
+
+	let canvas: HTMLCanvasElement;
+	let areas = [{}];
+
+	// TODO selection area needs to be a shape/rotated, not just x/y/w/h
+	function onMouseMove(event: MouseEvent): void {
+		if (!areas || !canvas) {
+			return;
+		}
+
+		let s: string | undefined = undefined;
+		let x = event.pageX - canvas.offsetLeft;
+		let y = event.pageY - canvas.offsetTop;
+
+		for (const a of areas) {
+			if (x > a.x && y > a.y && x < a.x + a.w && y < a.y + a.h) {
+				s = a.id;
+				break;
+			}
+		}
+
+		if (selected !== s) {
+			selected = s;
+			drawFloor();
+		}
+	}
+
+	function onClick(): void {
+		if (selected) {
+			goto('/team/' + selected);
+		}
+	}
+
+	$effect(() => {
+		drawFloor();
+	});
+
+	function drawFloor() {
+		let c = canvas;
+		if (!c) {
+			return;
+		}
+
+		c.height = window.innerHeight;
+		c.width = window.innerWidth;
+		var ctx = c.getContext('2d');
+		if (ctx == null) {
+			return;
+		}
+
+		ctx.textAlign = 'center';
+		ctx.textBaseline = 'middle';
+
+		let count = 0;
+		let minX = 50000,
+			minY = 50000;
+		let maxX = -50000,
+			maxY = -50000;
+		for (const team of teams) {
+			if (!team.location) {
+				continue;
+			}
+			count++;
+			const l = team.location;
+			minX = Math.min(minX, l.x);
+			minY = Math.min(minY, l.y);
+			maxX = Math.max(maxX, l.x);
+			maxY = Math.max(maxY, l.y);
+		}
+
+		if (count === 0) {
+			// no team locations - display a message instead
+			ctx.font = '20px Arial';
+			ctx.fillText('No map data', c.width / 2, c.height / 2);
+			return;
+		}
+
+		// buffer a desk's width around the edges
+		minX -= 3;
+		minY -= 3;
+		maxX += 3;
+		maxY += 3;
+
+		let dx = maxX - minX;
+		let dy = maxY - minY;
+		let scale = Math.min(c.width / dx, c.height / dy);
+
+		// center map on canvas
+		let ix = -minX * scale;
+		let iy = -minY * scale;
+
+		ix += (c.width - dx * scale) / 2;
+		iy += (c.height - dy * scale) / 2;
+
+		ctx.translate(ix, iy);
+
+		let desk_width = (mapInfo?.table_width || 1.8) * scale;
+		let desk_depth = (mapInfo?.table_depth || 1) * scale;
+		let area_width = (mapInfo?.table_area_width || 3) * scale;
+		let area_depth = (mapInfo?.table_area_depth || 2.2) * scale;
+
+		// TODO resize font based on canvas size
+		ctx.font = '12px Arial';
+		ctx.lineWidth = 0.75;
+
+		areas = [];
+		for (const team of teams) {
+			if (team.location) {
+				const l = team.location;
+
+				ctx.strokeStyle = 'black';
+
+				ctx.translate(l.x * scale, l.y * scale);
+
+				let rotation = ((90 - l.rotation) * Math.PI) / 180;
+				ctx.rotate(rotation);
+
+				ctx.fillStyle = '#eee';
+				ctx.fillRect(-area_width / 2, -area_depth / 2 + desk_depth / 2 + 0.21 * scale, area_width, area_depth);
+
+				if (team.id === selected) {
+					ctx.fillStyle = 'gray';
+					ctx.fillRect(-desk_width / 2, -desk_depth / 2, desk_width, desk_depth);
+					ctx.fillStyle = 'white';
+				} else {
+					ctx.strokeRect(-desk_width / 2, -desk_depth / 2, desk_width, desk_depth);
+					ctx.fillStyle = 'black';
+				}
+				const r = {
+					x: l.x * scale + ix,
+					y: l.y * scale + iy,
+					w: desk_width,
+					h: desk_depth,
+					id: team.id
+				};
+				areas.push(r);
+				
+				ctx.rotate(-rotation);
+
+				ctx.fillText(team.label, 0, 0);
+				ctx.translate(-l.x * scale, -l.y * scale);
+			}
+		}
+	}
+</script>
+
+<canvas
+	bind:this={canvas}
+	id="floor"
+	onmousemove={onMouseMove}
+	onclick={onClick}
+	class="w-full h-full"></canvas>
+
+<svelte:window onresize={drawFloor} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,8 @@
 	let { data } = $props();
 </script>
 
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 w-full h-full gap-2 p-2 overflow-auto">
+<div
+	class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 w-full h-full gap-2 p-2 overflow-auto">
 	{#each data.teams as team, i}
 		<div class="flex flex-row items-center bg-gray-200 rounded-md">
 			<a href="/team/{team.id}">

--- a/src/routes/map/+page.server.ts
+++ b/src/routes/map/+page.server.ts
@@ -1,0 +1,21 @@
+import { error } from '@sveltejs/kit';
+import { loadContest } from '$lib/state.svelte.js';
+
+export const load = async (_params) => {
+	const cc = await loadContest();
+	if (!cc) throw error(404);
+
+	await cc.loadTeams();
+
+	// map endpoint may not exist, so load it separately
+	try {
+		await cc.loadMapInfo();
+	} catch (e: any) {
+		// ignore
+	}
+
+	return {
+		mapInfo: cc.getMapInfo(),
+		teams: cc.getTeams()
+	};
+};

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import FloorMap from '$lib/ui/FloorMap.svelte';
+
+	let { data } = $props();
+
+	let selected = $state<string>();
+
+	let team = $derived(data.teams.find((t) => t.id === selected));
+</script>
+
+<div class="flex flex-col w-full h-full">
+	<div class="gap-2 w-full grow overflow-hidden">
+		<FloorMap mapInfo={data.mapInfo} teams={data.teams} bind:selected />
+	</div>
+
+	<div class="text-center">Selected team: {team?.display_name || team?.name}</div>
+</div>


### PR DESCRIPTION
Adds a FloorMap component (an HTML canvas) and a new page /map, not linked from anywhere else for now since it is 'beta' and missing some features [*]. It shows the contest floor if one exists for the contest with all the team desks. Hovering highlights a team [*], and clicking on them redirects to the team's page.

Contest types are updated to support the optional map-info and team location. FloorMap is a reusable component.

[*] Remaining issues:
- it's a bit plain, could use a bit more design.
- desks rotate, but the selection area doesn't - need to switch to shapes or rotated rects instead.
- font doesn't resize based on canvas size.
- component could use more features, e.g. show the logo on the selected team.
- onclick should just be an event, and let the client decide if it does anything.

Majority of #43.