### PR TITLE
Substitute missing images

### DIFF
--- a/src/lib/ui/Image.svelte
+++ b/src/lib/ui/Image.svelte
@@ -11,9 +11,13 @@
 
 	const util = new ContestUtil();
 	const bestRef = util.bestSquareLogo(ref, size * 20);
-	const imgSrc = bestRef?.href;
+	let imgSrc = $state(bestRef?.href);
+	
+	function onError(event: any): void {
+		imgSrc = '/images/icpc-logo.png';
+	}
 </script>
 
 {#if bestRef}
-	<img src={imgSrc} alt="logo" class="w-full h-full object-scale-down rounded-md" />
+	<img src={imgSrc} alt="logo" class="w-full h-full object-scale-down rounded-md" onerror={onError} />
 {/if}


### PR DESCRIPTION
If a contest doesn't have a banner or logos or photos, they're just omitted from the UI. The app is reactive to what is available, no problem.

However, if a contest says it has any of these images but then downloading the image fails (i.e. bad file reference), the UI is littered with little error icons. This just substitutes any missing images with the ICPC logo for now. We could just fancy and use a different image, or change based on whether it's a logo or photo etc, but for now at least the UI still looks clean.