### PR TITLE
Support for file reference tags

### DIFF
--- a/src/lib/contest-types.ts
+++ b/src/lib/contest-types.ts
@@ -36,6 +36,7 @@ export interface FileReference {
 	hash?: string;
 	width?: number;
 	height?: number;
+	tags?: string[];
 }
 
 export interface ContestState {

--- a/src/lib/contest-util.ts
+++ b/src/lib/contest-util.ts
@@ -55,7 +55,7 @@ export class ContestUtil {
 		return list;
 	}
 
-	bestSquareLogo(logos: FileReference[] | undefined, size: number): FileReference | undefined {
+	bestSquareLogo(logos: FileReference[] | undefined, size: number, tag?: string): FileReference | undefined {
 		if (!logos || logos.length == 0 || size < 1) {
 			return undefined;
 		}
@@ -64,14 +64,39 @@ export class ContestUtil {
 			return logos[0];
 		}
 
+		if (tag) {
+			// look for images that have the given tag
+			const arr = [];
+			for (const logo of logos) {
+				let found = false;
+				if (logo.tags) {
+					for (const tag2 of logo.tags) {
+						if (tag2 === tag) {
+							found = true;
+							break;
+						}
+					}
+				}
+				if (found) {
+					arr.push(logo);
+				}
+			}
+
+			// use the filtered list - unless it's empty
+			if (arr.length > 0) {
+				logos = arr;
+			}
+		}
+
 		// return an svg if possible
 		for (const logo of logos) {
-			if ('image/svg+xml' == logo.mime) return logo;
+			if ('image/svg+xml' == logo.mime) {
+				return logo;
+			}
 		}
 
 		let best: FileReference | undefined;
-		for (var i = 0; i < logos.length; i++) {
-			let ref = logos[i];
+		for (const ref of logos) {
 			if (ref.width != ref.height) {
 				continue;
 			}
@@ -96,7 +121,7 @@ export class ContestUtil {
 		return this.bestLogo(logos, size, size);
 	}
 
-	bestLogo(logos: FileReference[] | undefined, width: number, height: number): FileReference | undefined {
+	bestLogo(logos: FileReference[] | undefined, width: number, height: number, tag?: string): FileReference | undefined {
 		if (!logos || logos.length == 0 || width < 1 || height < 1) {
 			return undefined;
 		}
@@ -105,14 +130,39 @@ export class ContestUtil {
 			return logos[0];
 		}
 
+		if (tag) {
+			// look for images that have the given tag
+			const arr = [];
+			for (const logo of logos) {
+				let found = false;
+				if (logo.tags) {
+					for (const tag2 of logo.tags) {
+						if (tag2 === tag) {
+							found = true;
+							break;
+						}
+					}
+				}
+				if (found) {
+					arr.push(logo);
+				}
+			}
+
+			// use the filtered list - unless it's empty
+			if (arr.length > 0) {
+				logos = arr;
+			}
+		}
+
 		// return an svg if possible
 		for (const logo of logos) {
-			if ('image/svg+xml' == logo.mime) return logo;
+			if ('image/svg+xml' == logo.mime) {
+				return logo;
+			}
 		}
 
 		let best: FileReference | undefined;
-		for (var i = 0; i < logos.length; i++) {
-			let ref = logos[i];
+		for (const ref of logos) {
 			if (best == null) {
 				best = ref;
 			} else {

--- a/src/lib/ui/Banner.svelte
+++ b/src/lib/ui/Banner.svelte
@@ -5,11 +5,12 @@
 	interface Props {
 		ref?: FileReference[];
 		size?: 16 | 24 | 32 | 64;
+		tag?: string;
 	}
 
-	let { ref, size = 16 }: Props = $props();
+	let { ref, size = 16, tag }: Props = $props();
 </script>
 
 <div class="max-h-{size} h-{size} flex place-content-center">
-	<Image {ref} {size} />
+	<Image {ref} {size} {tag} />
 </div>

--- a/src/lib/ui/Image.svelte
+++ b/src/lib/ui/Image.svelte
@@ -5,12 +5,13 @@
 	interface Props {
 		ref?: FileReference[];
 		size: number;
+		tag?: string;
 	}
 
-	let { ref, size }: Props = $props();
+	let { ref, size, tag }: Props = $props();
 
 	const util = new ContestUtil();
-	const bestRef = util.bestSquareLogo(ref, size * 20);
+	const bestRef = util.bestSquareLogo(ref, size * 20, tag);
 	let imgSrc = $state(bestRef?.href);
 	
 	function onError(event: any): void {

--- a/src/lib/ui/Logo.svelte
+++ b/src/lib/ui/Logo.svelte
@@ -5,11 +5,12 @@
 	interface Props {
 		ref?: FileReference[];
 		size?: number;
+		tag?: string;
 	}
 
-	let { ref, size = 8 }: Props = $props();
+	let { ref, size = 8, tag }: Props = $props();
 </script>
 
 <div class="max-h-{size} max-w-{size} h-{size} w-{size} flex place-content-center">
-	<Image {ref} {size} />
+	<Image {ref} {size} {tag} />
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,7 +12,7 @@
 	<div class="flex flex-row gap-8 bg-gray-800 text-white p-4 items-center">
 		{#if data.logo && data.logo.length > 0}
 			<div class="w-12">
-				<Logo ref={data.logo} />
+				<Logo ref={data.logo} tag="dark" />
 			</div>
 		{/if}
 

--- a/src/routes/team/[id]/+layout.svelte
+++ b/src/routes/team/[id]/+layout.svelte
@@ -9,7 +9,7 @@
 	<div class="flex flex-row gap-4 bg-gray-700 text-white px-4 py-2 items-center">
 		{#if data.logo}
 			<div class="w-16 h-16">
-				<Logo ref={data.logo} size={16} />
+				<Logo ref={data.logo} size={16} tag="dark" />
 			</div>
 		{/if}
 


### PR DESCRIPTION
Adds support for file reference tags as per the draft spec, and exposes tags through the base Image, Banner, and Logo components.

The contest logo at the top left and the team logo underneath are the only two places right now where we always have a dark background, so I used the tag in these places. At some point we'll need to get fancier and support light/dark mode in the app, but this was used to prove that the API and core support is working for now.