### PR TITLE
Semi-intelligent caching and reloading

### DIFF
--- a/src/lib/contest-api.ts
+++ b/src/lib/contest-api.ts
@@ -57,6 +57,8 @@ export class ContestAPI {
 
 	timeDelta = [];
 
+	interval: any;
+
 	constructor(contestURL: string) {
 		if (!contestURL.endsWith('/')) {
 			contestURL += '/';
@@ -418,5 +420,30 @@ export class ContestAPI {
 				}
 			}
 		}
+	}
+
+	watch(): void {
+		if (this.interval) {
+			return this.interval;
+		}
+		console.log('watching');
+		this.interval = setInterval(async () => {
+			console.log('invalidating');
+			if (this.contest)
+				await this.loadContest(true);
+			if (this.submissions)
+				await this.loadSubmissions(true);
+			if (this.judgements)
+				await this.loadJudgements(true);
+			if (this.scoreboard)
+				await this.loadScoreboard(true);
+		}, 5000);
+	}
+
+	unwatch(): void {
+		if (!this.interval) {
+			return;
+		}
+		clearInterval(this.interval);
 	}
 }

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,7 +1,13 @@
+import type { ContestAPI } from './contest-api';
 import { Contests } from './contests';
 import { CONTEST } from './hardcoded.svelte';
 
+let contest: ContestAPI | undefined;
+
 export async function loadContest() {
+	if (contest)
+    	return contest;
+
 	const contestsImpl = new Contests(CONTEST.url);
 	await contestsImpl.loadContests();
 
@@ -9,5 +15,7 @@ export async function loadContest() {
 		console.log('error loading contests');
 	}
 
-	return contestsImpl.getContest();
+	contest = contestsImpl.getContest();
+	contest?.watch();
+	return contest;
 }

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,9 +1,11 @@
 import { loadContest } from '$lib/state.svelte.js';
 import { error } from '@sveltejs/kit';
 
-export const load = async (_params) => {
+export async function load({ depends }) {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
+
+	depends('data:contest');
 
 	await Promise.all([cc.loadContest()]);
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,10 +2,22 @@
 	import Banner from '$lib/ui/Banner.svelte';
 	import Clock from '$lib/ui/Clock.svelte';
 	import Logo from '$lib/ui/Logo.svelte';
+	import { onMount } from 'svelte';
 	import '../app.css';
 	import '../tailwind.css';
+	import { invalidate } from '$app/navigation';
 
 	let { data, children } = $props();
+
+	onMount(() => {
+		const interval = setInterval(() => {
+			invalidate('data:contest');
+		}, 5000);
+
+		return () => {
+			clearInterval(interval);
+		};
+	});
 </script>
 
 <div class="flex flex-col w-screen h-screen max-w-screen max-h-screen">

--- a/src/routes/scoreboard/+page.server.ts
+++ b/src/routes/scoreboard/+page.server.ts
@@ -2,7 +2,9 @@ import { error } from '@sveltejs/kit';
 import { ContestUtil } from '$lib/contest-util';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async (_params) => {
+export async function load({ depends }) {
+	depends('data:scoreboard');
+
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/scoreboard/+page.svelte
+++ b/src/routes/scoreboard/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { invalidateAll } from '$app/navigation';
+	import { invalidate } from '$app/navigation';
 	import { flip } from 'svelte/animate';
 	import ScoreboardHeader from '$lib/ui/ScoreboardHeader.svelte';
 	import ScoreboardRow from '$lib/ui/ScoreboardRow.svelte';
@@ -9,8 +9,8 @@
 
 	onMount(() => {
 		const interval = setInterval(() => {
-			invalidateAll();
-		}, 3000);
+			invalidate('data:scoreboard');
+		}, 1000);
 
 		return () => {
 			clearInterval(interval);


### PR DESCRIPTION
Fixes the issue in state where the contest would be reloaded on every request - i.e. every user was hitting every relevant endpoint on every navigation. This was causing # of clients * # of pages navigated on both the node backend and the Contest API server - clearly too much to scale.

Now, all contest data is loaded on first request by any client and cached for all users. The server side starts a watch and reloads only the contest, submissions, judgements, and scoreboard endpoints for all users every 5s. The client side polls for these updates every 5s as well, but async, these are not lined up.

Net: the node server now gets 1-2 X # clients requests per 5s, but the Contest API backend only gets 2 requests total every 5s.

Fixes #42.