### PR TITLE
Increase API response time from 1s to 2s

### DIFF
--- a/src/lib/contest-api.ts
+++ b/src/lib/contest-api.ts
@@ -100,7 +100,7 @@ export class ContestAPI {
 				secureConnect: 2000,
 				socket: 2000,
 				send: 10000,
-				response: 1000
+				response: 2000
 			}
 		};
 


### PR DESCRIPTION
I've randomly hit the response timelimit a couple times now, just bump it to avoid issues due to slightly slow contest api server.