### PR TITLE
Use consistent load function

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,7 +1,7 @@
 import { loadContest } from '$lib/state.svelte.js';
 import { error } from '@sveltejs/kit';
 
-export async function load({ depends }) {
+export const load = async ({ depends }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -2,7 +2,7 @@ import { error } from '@sveltejs/kit';
 import { ContestUtil } from '$lib/contest-util';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async (_params) => {
+export const load = async () => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/map/+page.server.ts
+++ b/src/routes/map/+page.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async (_params) => {
+export const load = async () => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/problem/[id]/+page.server.ts
+++ b/src/routes/problem/[id]/+page.server.ts
@@ -4,7 +4,7 @@ import { timeToMin } from '$lib/contest-time-util';
 import type { Judgement, JudgementType } from '$lib/contest-types';
 import { ContestUtil } from '$lib/contest-util';
 
-export const load = async (params) => {
+export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
@@ -19,7 +19,7 @@ export const load = async (params) => {
 
 	const problems = cc.getProblems();
 
-	const problem = problems?.find((p) => p.id && p.id === params.params.id);
+	const problem = problems?.find((p) => p.id && p.id === params.id);
 	if (!problem) throw error(404);
 
 	const languages = cc.getLanguages();

--- a/src/routes/scoreboard/+page.server.ts
+++ b/src/routes/scoreboard/+page.server.ts
@@ -2,7 +2,7 @@ import { error } from '@sveltejs/kit';
 import { ContestUtil } from '$lib/contest-util';
 import { loadContest } from '$lib/state.svelte.js';
 
-export async function load({ depends }) {
+export const load = async ({ depends }) => {
 	depends('data:scoreboard');
 
 	const cc = await loadContest();

--- a/src/routes/team/[id]/+layout.server.ts
+++ b/src/routes/team/[id]/+layout.server.ts
@@ -2,7 +2,7 @@ import { error } from '@sveltejs/kit';
 import { ContestUtil } from '$lib/contest-util';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async (params) => {
+export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
@@ -15,7 +15,7 @@ export const load = async (params) => {
 	]);
 
 	const teams = cc.getTeams();
-	const team = teams?.find((t) => t.id && t.id === params.params.id);
+	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);
 
 	const orgs = cc.getOrganizations();

--- a/src/routes/team/[id]/+page.server.ts
+++ b/src/routes/team/[id]/+page.server.ts
@@ -6,7 +6,7 @@ import type { Judgement, JudgementType } from '$lib/contest-types.js';
 import * as countries from 'i18n-iso-countries';
 import en from 'i18n-iso-countries/langs/en.json';
 
-export const load = async (params) => {
+export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
@@ -23,7 +23,7 @@ export const load = async (params) => {
 	]);
 
 	const teams = cc.getTeams();
-	const team = teams?.find((t) => t.id && t.id === params.params.id);
+	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);
 
 	const orgs = cc.getOrganizations();

--- a/src/routes/team/[id]/desktop/+page.server.ts
+++ b/src/routes/team/[id]/desktop/+page.server.ts
@@ -1,14 +1,14 @@
 import { error } from '@sveltejs/kit';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async (params) => {
+export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
 	await Promise.all([cc.loadTeams()]);
 
 	const teams = cc.getTeams();
-	const team = teams?.find((t) => t.id && t.id === params.params.id);
+	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);
 
 	return {

--- a/src/routes/team/[id]/pip/+page.server.ts
+++ b/src/routes/team/[id]/pip/+page.server.ts
@@ -1,14 +1,14 @@
 import { error } from '@sveltejs/kit';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async (params) => {
+export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
 	await Promise.all([cc.loadTeams()]);
 
 	const teams = cc.getTeams();
-	const team = teams?.find((t) => t.id && t.id === params.params.id);
+	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);
 
 	return {

--- a/src/routes/team/[id]/rpip/+page.server.ts
+++ b/src/routes/team/[id]/rpip/+page.server.ts
@@ -1,14 +1,14 @@
 import { error } from '@sveltejs/kit';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async (params) => {
+export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
 	await Promise.all([cc.loadTeams()]);
 
 	const teams = cc.getTeams();
-	const team = teams?.find((t) => t.id && t.id === params.params.id);
+	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);
 
 	return {

--- a/src/routes/team/[id]/side-side/+page.server.ts
+++ b/src/routes/team/[id]/side-side/+page.server.ts
@@ -1,14 +1,14 @@
 import { error } from '@sveltejs/kit';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async (params) => {
+export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
 	await Promise.all([cc.loadTeams()]);
 
 	const teams = cc.getTeams();
-	const team = teams?.find((t) => t.id && t.id === params.params.id);
+	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);
 
 	return {


### PR DESCRIPTION
Not sure if the recommendation changed over time (Svelte 5?), but use the load function in the form `export const load = async () =>` from the SvelteKit docs. All the load functions are now consistent, we don't have params.params anymore, and makes it easy to add depends.