### PR TITLE
Video can only play a single video

### DIFF
--- a/src/lib/ui/Video.svelte
+++ b/src/lib/ui/Video.svelte
@@ -7,14 +7,14 @@
 	import 'video.js/dist/video-js.css'; // default Video.js CSS
 
 	interface Props {
-		ref?: FileReference[];
+		ref?: FileReference;
 		type: string;
 	}
 
 	let { ref, type }: Props = $props();
 
-	let src = $derived(ref && ref.length > 0 ? ref[0].href : undefined);
-	let mime = $derived(ref && ref.length > 0 ? ref[0].mime : undefined);
+	let src = $derived(ref ? ref.href : undefined);
+	let mime = $derived(ref ? ref.mime : undefined);
 
 	let videoNode = $state<HTMLElement | string>('');
 	let player = $state<Player>();

--- a/src/routes/team/[id]/desktop/+page.svelte
+++ b/src/routes/team/[id]/desktop/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<Video ref={data.team.desktop} type="desktop" />
+<Video ref={data.team.desktop?.[0]} type="desktop" />

--- a/src/routes/team/[id]/pip/+page.svelte
+++ b/src/routes/team/[id]/pip/+page.svelte
@@ -5,9 +5,9 @@
 </script>
 
 <div class="w-full h-full relative">
-	<Video ref={data.team.desktop} type="desktop" />
+	<Video ref={data.team.desktop?.[0]} type="desktop" />
 
 	<div class="w-84 aspect-video absolute top-8 right-0">
-		<Video ref={data.team.webcam} type="webcam" />
+		<Video ref={data.team.webcam?.[0]} type="webcam" />
 	</div>
 </div>

--- a/src/routes/team/[id]/rpip/+page.svelte
+++ b/src/routes/team/[id]/rpip/+page.svelte
@@ -5,9 +5,9 @@
 </script>
 
 <div class="w-full h-full relative">
-	<Video ref={data.team.webcam} type="webcam" />
+	<Video ref={data.team.webcam?.[0]} type="webcam" />
 
 	<div class="w-84 aspect-video absolute top-8 right-0">
-		<Video ref={data.team.desktop} type="desktop" />
+		<Video ref={data.team.desktop?.[0]} type="desktop" />
 	</div>
 </div>

--- a/src/routes/team/[id]/side-side/+page.svelte
+++ b/src/routes/team/[id]/side-side/+page.svelte
@@ -5,6 +5,6 @@
 </script>
 
 <div class="flex flex-row justify-items-stretch w-full h-full">
-	<Video ref={data.team.desktop} type="desktop" />
-	<Video ref={data.team.webcam} type="webcam" />
+	<Video ref={data.team.desktop?.[0]} type="desktop" />
+	<Video ref={data.team.webcam?.[0]} type="webcam" />
 </div>

--- a/src/routes/team/[id]/webcam/+page.svelte
+++ b/src/routes/team/[id]/webcam/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<Video ref={data.team.webcam} type="webcam" />
+<Video ref={data.team.webcam?.[0]} type="webcam" />


### PR DESCRIPTION
The Video component was created with ref?:FileReference[] because that was expedient at the time, and it would always play the first reference. However, it is only meant to play a single video, and FileReference[] could contain more than one. (e.g. for WF Moscow it was going to be one video per team member, and reaction videos are 1 for desktop and 1 for webcam).

This just changes it to ref?:FileReference and the client is responsible for picking which ref to play.