### PR TITLE
Improved contest logging

### DIFF
--- a/src/lib/contests.ts
+++ b/src/lib/contests.ts
@@ -2,7 +2,7 @@
  * Copyright later.
  */
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
-import got from 'got';
+import got, { HTTPError, RequestError } from 'got';
 import type { Contest } from './contest-types';
 import { ContestAPI } from './contest-api';
 import { CONTEST } from './hardcoded.svelte';
@@ -26,15 +26,15 @@ export class Contests {
 			const response = await got.get(this.baseURL + 'contests', this.getHttpOptions());
 			this.contests = JSON.parse(response.body) as Contest[];
 			const endTime = performance.now();
-			console.log(`Fetched ${this.baseURL} in ${endTime - startTime}ms`);
+			console.log(`Fetched ${this.baseURL} in ${(endTime - startTime).toFixed(1)}ms`);
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} catch (requestErr: any) {
-			// unable to fetch the extensions
-			// extract only the error message
-			if (requestErr.message) {
-				throw new Error(`Unable to fetch contests: ${String(requestErr.message)}`);
+		} catch (error: any) {
+			if (error instanceof HTTPError) {
+				throw new Error(`HTTP error ${error.response.statusCode} loading contests: ${error.response.statusMessage}`);
+			} else if (error instanceof RequestError) {
+				throw new Error(`Error loading contests: ${error.code}`);
 			} else {
-				throw new Error(`Unable to fetch contests: ${String(requestErr)}`);
+				throw new Error(`Unexpected error loading contests: ${error}`);
 			}
 		}
 	}

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -4,18 +4,48 @@ import { CONTEST } from './hardcoded.svelte';
 
 let contest: ContestAPI | undefined;
 
+class Mutex {
+  private locked: boolean = false;
+  private queue: (() => void)[] = [];
+
+  async lock() {
+    if (this.locked) {
+      return new Promise<void>(resolve => this.queue.push(resolve));
+    }
+    this.locked = true;
+  }
+
+  unlock() {
+    this.locked = false;
+    if (this.queue.length > 0) {
+      const next = this.queue.shift();
+      next?.();
+    }
+  }
+}
+
+const mutex = new Mutex();
+
 export async function loadContest() {
 	if (contest)
     	return contest;
 
-	const contestsImpl = new Contests(CONTEST.url);
-	await contestsImpl.loadContests();
+	await mutex.lock();
+	try {
+		if (contest)
+    		return contest;
 
-	if (!contestsImpl) {
-		console.log('error loading contests');
-	}
+		const contestsImpl = new Contests(CONTEST.url);
+		await contestsImpl.loadContests();
 
-	contest = contestsImpl.getContest();
-	contest?.watch();
-	return contest;
+		if (!contestsImpl) {
+			console.log('error loading contests');
+		}
+
+		contest = contestsImpl.getContest();
+		contest?.watch();
+		return contest;
+	} finally {
+		mutex.unlock();
+	}	
 }


### PR DESCRIPTION
Fixes a few related issues:
- There was a race condition and sometimes two copies of the contest were being loaded (and updated indefinitely). Added a simple mutex to state.svelte.ts for now to avoid this.
- Reduced logging, only 1 output (success or failure) per HTTP request.
- Added correct got HTTP error logging and included url, response code in error message.
- Reduced ms values to one decimal place and improved/simplified the messages.
- Added a couple missing types.