### PR TITLE
Improved floor map

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -9,6 +9,12 @@ export async function load({ depends }) {
 
 	await Promise.all([cc.loadContest()]);
 
+	try {
+		await Promise.all([cc.loadMapInfo()]);
+	} catch (err) {
+		// TODO ignore failure to load map data for now. avoid (re)loading in the future
+	}
+
 	const contest = cc.getContest();
 	if (!contest) throw error(404);
 
@@ -16,6 +22,7 @@ export async function load({ depends }) {
 		contest: contest,
 		name: contest.formal_name || contest.name,
 		banner: contest.banner,
-		logo: contest.logo
+		logo: contest.logo,
+		map: cc.getMapInfo()
 	};
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -32,6 +32,10 @@
 
 		<div class="w-48"><Clock contest={data.contest} /></div>
 
+		{#if data.map}
+			<div class="text-lg"><a href="/map">Map</a></div>
+		{/if}
+
 		<div class="text-lg"><a href="/scoreboard">Scoreboard</a></div>
 	</div>
 

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1,17 +1,21 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
+	import type { Team } from '$lib/contest-types.js';
 	import FloorMap from '$lib/ui/FloorMap.svelte';
 
 	let { data } = $props();
 
-	let selected = $state<string>();
+	let selected = $state<Team>();
 
-	let team = $derived(data.teams.find((t) => t.id === selected));
+	function onClick(team: Team): void {
+		goto('/team/' + team.id);
+	}
 </script>
 
 <div class="flex flex-col w-full h-full">
 	<div class="gap-2 w-full grow overflow-hidden">
-		<FloorMap mapInfo={data.mapInfo} teams={data.teams} bind:selected />
+		<FloorMap mapInfo={data.mapInfo} teams={data.teams} bind:selected onclick={(team) => onClick(team)} />
 	</div>
 
-	<div class="text-center">Selected team: {team?.display_name || team?.name}</div>
+	<div class="text-center">Team: {selected?.display_name || selected?.name}</div>
 </div>


### PR DESCRIPTION
- If floor map is available, add a link in the header beside the scoreboard.
- Font is resized based on the size of the canvas.
- Spares (empty desks) are included.
- Selection is a Team (vs string id).
- onclick is a proper Svelte event now, and passes the team you clicked on to the function.
- Issues with aspect ratio changing fixed.
- Team selection works now - except it doesn't take team rotation into account yet.

Fixes #43.