### PR TITLE
Reactive team and problem pages

### DIFF
--- a/src/routes/problem/[id]/+page.server.ts
+++ b/src/routes/problem/[id]/+page.server.ts
@@ -4,7 +4,8 @@ import { timeToMin } from '$lib/contest-time-util';
 import type { Judgement, JudgementType } from '$lib/contest-types';
 import { ContestUtil } from '$lib/contest-util';
 
-export const load = async ({ params }) => {
+export const load = async ({ params, depends }) => {
+	depends('data:problem');
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -1,11 +1,23 @@
 <script lang="ts">
+	import { invalidate } from '$app/navigation';
 	import JudgementType from '$lib/ui/JudgementType.svelte';
 	import Problem from '$lib/ui/Problem.svelte';
+	import { onMount } from 'svelte';
 
 	let { data } = $props();
+
+	onMount(() => {
+		const interval = setInterval(() => {
+			invalidate('data:problem');
+		}, 3000);
+
+		return () => {
+			clearInterval(interval);
+		};
+	});
 </script>
 
-<div class="flex flex-col p-2 gap-1">
+<div class="flex flex-col p-2 gap-1 h-full overflow-auto">
 	<div class="flex flex-col">
 		<div class="text-xl">Problem</div>
 		<div class="flex flex-row gap-x-2">

--- a/src/routes/team/[id]/+layout.server.ts
+++ b/src/routes/team/[id]/+layout.server.ts
@@ -2,7 +2,8 @@ import { error } from '@sveltejs/kit';
 import { ContestUtil } from '$lib/contest-util';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async ({ params }) => {
+export const load = async ({ params, depends }) => {
+	depends('data:team-layout');
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/team/[id]/+layout.svelte
+++ b/src/routes/team/[id]/+layout.svelte
@@ -1,8 +1,20 @@
 <script lang="ts">
+	import { invalidate } from '$app/navigation';
 	import Logo from '$lib/ui/Logo.svelte';
 	import ScoreboardRow from '$lib/ui/ScoreboardRow.svelte';
+	import { onMount } from 'svelte';
 
 	let { data, children } = $props();
+
+	onMount(() => {
+		const interval = setInterval(() => {
+			invalidate('data:team-layout');
+		}, 3000);
+
+		return () => {
+			clearInterval(interval);
+		};
+	});
 </script>
 
 <div class="w-full h-full max-w-full max-h-full overflow-hidden flex flex-col">

--- a/src/routes/team/[id]/+page.server.ts
+++ b/src/routes/team/[id]/+page.server.ts
@@ -6,7 +6,8 @@ import type { Judgement, JudgementType } from '$lib/contest-types.js';
 import * as countries from 'i18n-iso-countries';
 import en from 'i18n-iso-countries/langs/en.json';
 
-export const load = async ({ params }) => {
+export const load = async ({ params, depends }) => {
+	depends('data:team');
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
+	import { invalidate } from '$app/navigation';
 	import JudgementType from '$lib/ui/JudgementType.svelte';
 	import Person from '$lib/ui/Person.svelte';
 	import Photo from '$lib/ui/Photo.svelte';
 	import Problem from '$lib/ui/Problem.svelte';
+	import { onMount } from 'svelte';
 
 	let { data } = $props();
+
+	onMount(() => {
+		const interval = setInterval(() => {
+			invalidate('data:team');
+		}, 3000);
+
+		return () => {
+			clearInterval(interval);
+		};
+	});
 </script>
 
 <div class="flex flex-col p-2 gap-1 h-full overflow-auto">


### PR DESCRIPTION
The only connection to the backend contest API server is through the node server, which is periodically polling the contest API for changes.

On the browser side there's currently no way to know when that backend data has changed, so the scoreboard and clock are invalidating their data periodically to force a refresh. This just adds the same auto-reloading to the teams/ and problems/ pages. Everything should be reactive and auto refresh again.

Is there a better way? Almost definitely. :) The backend should probably be using the event feed so that updates are immediate and there's no polling, and the frontend should be using a websocket or even a periodic poll to see what or if anything has changed instead of blindly reloading. But, that's for another day.