### PR TITLE
Handle reload error without crashing

### DIFF
--- a/src/lib/contest-api.ts
+++ b/src/lib/contest-api.ts
@@ -430,14 +430,18 @@ export class ContestAPI {
 		console.log(`Watching ${this.id}`);
 		this.interval = setInterval(async () => {
 			console.log(`Invalidating ${this.id}`);
-			if (this.contest)
-				await this.loadContest(true);
-			if (this.submissions)
-				await this.loadSubmissions(true);
-			if (this.judgements)
-				await this.loadJudgements(true);
-			if (this.scoreboard)
-				await this.loadScoreboard(true);
+			try {
+				if (this.contest)
+					await this.loadContest(true);
+				if (this.submissions)
+					await this.loadSubmissions(true);
+				if (this.judgements)
+					await this.loadJudgements(true);
+				if (this.scoreboard)
+					await this.loadScoreboard(true);
+			} catch (error: any) {
+				console.error(`Error reloading contest data: ${error}`);
+			}
 		}, 5000);
 	}
 


### PR DESCRIPTION
Today, no contest data is preloaded. We could do a quick cache of everything (and event feed support is in progress...), but for now the first person to hit any page requiring data triggers the load just of that part of the contest; after a few pages or people everything is cached and fast.

If the Contest API it is connected to or the network fails during this period it's not a huge deal; the one person will get an error but it should retry for the next person until it succeeds, then everything becomes cached and really fast.

Every 5s the data that tends to change (submissions, judgements, scoreboard) is force-reloaded, and if that fails it causes the crash in #75. This just puts a catch block around it so that there will be a log message, and it should try again in 5s.

Fixes #75.