### PR TITLE
Create contest-api package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"vitest": "^2.1.9"
 	},
 	"dependencies": {
+		"contest-api": "workspace:*",
 		"got": "^14.4.9",
 		"i18n-iso-countries": "^7.14.0",
 		"mpegts.js": "1.8.0",

--- a/packages/contest-api/package.json
+++ b/packages/contest-api/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "contest-api",
+	"version": "0.0.2",
+	"type": "module",
+	"main": "./src/index.ts",
+	"types": "./src/index.ts",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"test": "vitest"
+	},
+	"dependencies": {
+		"got": "^14.4.9"
+	},
+	"devDependencies": {
+		"@types/node": "^24.6.2",
+		"msw": "^2.12.4",
+		"typescript": "^5.9.3",
+		"vitest": "^2.1.9"
+	}
+}
+

--- a/packages/contest-api/src/contest-api.test.ts
+++ b/packages/contest-api/src/contest-api.test.ts
@@ -61,3 +61,4 @@ test('load groups', async () => {
 	expect(groups[2].id).toBe('3');
 	expect(groups[2].name).toBe('Rest');
 });
+

--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -26,7 +26,11 @@ import type {
 	Submission,
 	Team
 } from './contest-types';
-import { CONTEST } from './hardcoded.svelte';
+
+export interface Credentials {
+	user?: string;
+	password?: string;
+}
 
 export class ContestAPI {
 	contest?: Contest;
@@ -55,16 +59,18 @@ export class ContestAPI {
 	contestURL: string;
 	baseURL: string;
 	serverURL: string;
+	credentials?: Credentials;
 
 	timeDelta = [];
 
 	interval: any;
 
-	constructor(contestURL: string) {
+	constructor(contestURL: string, credentials?: Credentials) {
 		if (!contestURL.endsWith('/')) {
 			contestURL += '/';
 		}
 		this.contestURL = contestURL;
+		this.credentials = credentials;
 
 		// base url, e.g. http://example.com/api/
 		const bInd = this.contestURL.indexOf('/api/contests/');
@@ -90,8 +96,8 @@ export class ContestAPI {
 		const httpsOptions: HttpsOptions = {
 			rejectUnauthorized: false
 		};
-		const user = CONTEST.user;
-		const password = CONTEST.password;
+		const user = this.credentials?.user;
+		const password = this.credentials?.password;
 		const options: OptionsOfTextResponseBody = {
 			https: httpsOptions,
 			retry: { limit: 0 },
@@ -452,3 +458,4 @@ export class ContestAPI {
 		clearInterval(this.interval);
 	}
 }
+

--- a/packages/contest-api/src/contest-time-util.ts
+++ b/packages/contest-api/src/contest-time-util.ts
@@ -187,3 +187,4 @@ export function formatContestTime(time: number, floor: boolean): string {
 	sb.push(seconds);
 	return sb.join('');
 }
+

--- a/packages/contest-api/src/contest-types.ts
+++ b/packages/contest-api/src/contest-types.ts
@@ -289,3 +289,4 @@ export interface Notification {
 	data?: [] | {};
 	token?: string;
 }
+

--- a/packages/contest-api/src/contest-util.ts
+++ b/packages/contest-api/src/contest-util.ts
@@ -171,3 +171,4 @@ export class ContestUtil {
 		return problems.sort((a, b) => (a.ordinal > b.ordinal ? 1 : b.ordinal > a.ordinal ? -1 : 0));
 	}
 }
+

--- a/packages/contest-api/src/contests.ts
+++ b/packages/contest-api/src/contests.ts
@@ -4,19 +4,20 @@
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
 import got, { HTTPError, RequestError } from 'got';
 import type { Contest } from './contest-types';
-import { ContestAPI } from './contest-api';
-import { CONTEST } from './hardcoded.svelte';
+import { ContestAPI, type Credentials } from './contest-api';
 
 export class Contests {
 	contests: Contest[] | undefined;
 	contestObjs: Contest[] | undefined;
 	baseURL: string;
+	credentials?: Credentials;
 
-	constructor(baseURL: string) {
+	constructor(baseURL: string, credentials?: Credentials) {
 		if (!baseURL.endsWith('/')) {
 			baseURL += '/';
 		}
 		this.baseURL = baseURL;
+		this.credentials = credentials;
 		console.log('Contest API URL: ' + this.baseURL);
 	}
 
@@ -43,9 +44,13 @@ export class Contests {
 		const httpsOptions: HttpsOptions = {
 			rejectUnauthorized: false
 		};
+		const user = this.credentials?.user;
+		const password = this.credentials?.password;
 		const options: OptionsOfTextResponseBody = {
 			https: httpsOptions,
 			retry: { limit: 0 },
+			username: user,
+			password: password,
 			// specify short timeout
 			timeout: {
 				lookup: 2000,
@@ -72,17 +77,17 @@ export class Contests {
 		return this.contests;
 	}
 
-	getContest(): ContestAPI | undefined {
+	getContest(contestId?: string): ContestAPI | undefined {
 		if (!this.contests || this.contests.length === 0) {
 			return undefined;
 		}
 		let contestURL = this.baseURL + 'contests/';
-		if (CONTEST.contest_id && CONTEST.contest_id.length > 0) {
-			contestURL += CONTEST.contest_id;
+		if (contestId && contestId.length > 0) {
+			contestURL += contestId;
 		} else {
 			contestURL += this.contests[0].id;
 		}
-		return new ContestAPI(contestURL);
+		return new ContestAPI(contestURL, this.credentials);
 	}
 
 	getContestObjs(): Contest[] | undefined {
@@ -102,3 +107,4 @@ export class Contests {
 		this.contests = [];
 	}
 }
+

--- a/packages/contest-api/src/index.ts
+++ b/packages/contest-api/src/index.ts
@@ -1,0 +1,6 @@
+export * from './contest-api';
+export * from './contest-types';
+export * from './contest-time-util';
+export * from './contest-util';
+export * from './contests';
+

--- a/packages/contest-api/tsconfig.json
+++ b/packages/contest-api/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ES2022",
+		"lib": ["ES2022"],
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"declaration": true,
+		"outDir": "./dist"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      contest-api:
+        specifier: workspace:*
+        version: link:packages/contest-api
       got:
         specifier: ^14.4.9
         version: 14.4.9
@@ -84,6 +87,25 @@ importers:
       vite:
         specifier: ^6.3.6
         version: 6.3.6(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.30.1)(yaml@2.7.0)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@24.6.2)(lightningcss@1.30.1)(msw@2.12.4(@types/node@24.6.2)(typescript@5.9.3))
+
+  packages/contest-api:
+    dependencies:
+      got:
+        specifier: ^14.4.9
+        version: 14.4.9
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.2
+        version: 24.6.2
+      msw:
+        specifier: ^2.12.4
+        version: 2.12.4(@types/node@24.6.2)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@24.6.2)(lightningcss@1.30.1)(msw@2.12.4(@types/node@24.6.2)(typescript@5.9.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
     - '*'
+    - 'packages/*'
     - tests/*
 onlyBuiltDependencies:
     - esbuild

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,5 +1,5 @@
-import type { ContestAPI } from './contest-api';
-import { Contests } from './contests';
+import type { ContestAPI } from 'contest-api';
+import { Contests } from 'contest-api';
 import { CONTEST } from './hardcoded.svelte';
 
 let contest: ContestAPI | undefined;
@@ -35,14 +35,21 @@ export async function loadContest() {
 		if (contest)
     		return contest;
 
-		const contestsImpl = new Contests(CONTEST.url);
-		await contestsImpl.loadContests();
+		if (!CONTEST.url) {
+			throw new Error('CONTEST.url is not defined');
+		}
+		
+		const contests = new Contests(CONTEST.url, {
+			user: CONTEST.user,
+			password: CONTEST.password
+		});
+		await contests.loadContests();
 
-		if (!contestsImpl) {
+		if (!contests) {
 			console.log('error loading contests');
 		}
 
-		contest = contestsImpl.getContest();
+		contest = contests.getContest(CONTEST?.contest_id);
 		contest?.watch();
 		return contest;
 	} finally {

--- a/src/lib/ui/Banner.svelte
+++ b/src/lib/ui/Banner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { FileReference } from '$lib/contest-types';
+	import type { FileReference } from 'contest-api';
 	import Image from './Image.svelte';
 
 	interface Props {

--- a/src/lib/ui/Clock.svelte
+++ b/src/lib/ui/Clock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { getContestTime, getContestState } from '$lib/contest-time-util';
-	import type { Contest } from '$lib/contest-types';
+	import { getContestTime, getContestState } from 'contest-api';
+	import type { Contest } from 'contest-api';
 	import { onMount } from 'svelte';
 
 	interface Props {

--- a/src/lib/ui/FloorMap.svelte
+++ b/src/lib/ui/FloorMap.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { MapInfo, Team } from '$lib/contest-types';
+	import type { MapInfo, Team } from 'contest-api';
 
 	interface Props {
 		mapInfo?: MapInfo;

--- a/src/lib/ui/Image.svelte
+++ b/src/lib/ui/Image.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import type { FileReference } from '$lib/contest-types';
-	import { ContestUtil } from '../contest-util';
+	import type { FileReference } from 'contest-api';
+	import { ContestUtil } from 'contest-api';
 
 	interface Props {
 		ref?: FileReference[];

--- a/src/lib/ui/JudgementType.svelte
+++ b/src/lib/ui/JudgementType.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { JudgementType } from '$lib/contest-types';
+	import type { JudgementType } from 'contest-api';
 
 	interface Props {
 		judgement_type?: JudgementType;

--- a/src/lib/ui/Logo.svelte
+++ b/src/lib/ui/Logo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { FileReference } from '$lib/contest-types';
+	import type { FileReference } from 'contest-api';
 	import Image from './Image.svelte';
 
 	interface Props {

--- a/src/lib/ui/Person.svelte
+++ b/src/lib/ui/Person.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Person } from '$lib/contest-types';
+	import type { Person } from 'contest-api';
 	import Image from './Image.svelte';
 
 	interface Props {

--- a/src/lib/ui/Photo.svelte
+++ b/src/lib/ui/Photo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { FileReference } from '$lib/contest-types';
+	import type { FileReference } from 'contest-api';
 	import Image from './Image.svelte';
 
 	interface Props {

--- a/src/lib/ui/Problem.svelte
+++ b/src/lib/ui/Problem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { parseHexColor, darker, rgbToHex } from '$lib/color-util.js';
-	import type { Problem } from '$lib/contest-types';
+	import type { Problem } from 'contest-api';
 
 	interface Props {
 		problem?: Problem;

--- a/src/lib/ui/ScoreboardHeader.svelte
+++ b/src/lib/ui/ScoreboardHeader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Problem as ProblemObj } from '$lib/contest-types.js';
+	import type { Problem as ProblemObj } from 'contest-api';
 	import Problem from './Problem.svelte';
 	import { getColumns } from './scoreboard-util';
 	import { goto } from '$app/navigation';

--- a/src/lib/ui/ScoreboardRow.svelte
+++ b/src/lib/ui/ScoreboardRow.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import Logo from './Logo.svelte';
 	import { parseHexColor, rgbToHex, FAILED, SOLVED, PENDING, SCORING_MID } from '$lib/color-util.js';
-	import { timeToMin } from '$lib/contest-time-util.js';
-	import type { FileReference, Problem, ScoreboardProblem, ScoreboardRow, Team } from '$lib/contest-types.js';
+	import { timeToMin } from 'contest-api';
+	import type { FileReference, Problem, ScoreboardProblem, ScoreboardRow, Team } from 'contest-api';
 	import { getColumns } from './scoreboard-util';
 
 	interface Props {

--- a/src/lib/ui/Video.svelte
+++ b/src/lib/ui/Video.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { FileReference } from '$lib/contest-types';
+	import type { FileReference } from 'contest-api';
 
 	import { onMount, onDestroy } from 'svelte';
 	import videojs from 'video.js';

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { ContestUtil } from '$lib/contest-util';
+import { ContestUtil } from 'contest-api';
 import { loadContest } from '$lib/state.svelte.js';
 
 export const load = async () => {

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import type { Team } from '$lib/contest-types.js';
+	import type { Team } from 'contest-api';
 	import FloorMap from '$lib/ui/FloorMap.svelte';
 
 	let { data } = $props();

--- a/src/routes/problem/[id]/+page.server.ts
+++ b/src/routes/problem/[id]/+page.server.ts
@@ -1,8 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { loadContest } from '$lib/state.svelte.js';
-import { timeToMin } from '$lib/contest-time-util';
-import type { Judgement, JudgementType } from '$lib/contest-types';
-import { ContestUtil } from '$lib/contest-util';
+import { timeToMin, ContestUtil } from 'contest-api';
+import type { Judgement, JudgementType } from 'contest-api';
 
 export const load = async ({ params, depends }) => {
 	depends('data:problem');

--- a/src/routes/scoreboard/+page.server.ts
+++ b/src/routes/scoreboard/+page.server.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { ContestUtil } from '$lib/contest-util';
+import { ContestUtil } from 'contest-api';
 import { loadContest } from '$lib/state.svelte.js';
 
 export const load = async ({ depends }) => {

--- a/src/routes/team/[id]/+layout.server.ts
+++ b/src/routes/team/[id]/+layout.server.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { ContestUtil } from '$lib/contest-util';
+import { ContestUtil } from 'contest-api';
 import { loadContest } from '$lib/state.svelte.js';
 
 export const load = async ({ params, depends }) => {

--- a/src/routes/team/[id]/+page.server.ts
+++ b/src/routes/team/[id]/+page.server.ts
@@ -1,8 +1,8 @@
 import { error } from '@sveltejs/kit';
-import { ContestUtil } from '$lib/contest-util';
+import { ContestUtil } from 'contest-api';
 import { loadContest } from '$lib/state.svelte.js';
-import { timeToMin } from '$lib/contest-time-util.js';
-import type { Judgement, JudgementType } from '$lib/contest-types.js';
+import { timeToMin } from 'contest-api';
+	import type { Judgement, JudgementType } from 'contest-api';
 import * as countries from 'i18n-iso-countries';
 import en from 'i18n-iso-countries/langs/en.json';
 


### PR DESCRIPTION
Moves the core contest API files into its own package named 'contest-api'. This cleanly separates the reusable typescript Contest API logic (which could be published to npmjs or reused elsewhere) from the rest of the application.