### PR TITLE
Dark mode fixes and initial hover color

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,1 +1,5 @@
 @import 'tailwindcss';
+
+@theme {
+  --color-hover: light-dark(var(--color-gray-600), var(--color-gray-700));
+}

--- a/src/lib/ui/DarkModeToggle.svelte
+++ b/src/lib/ui/DarkModeToggle.svelte
@@ -12,7 +12,7 @@
 <button
   type="button"
 	onclick={toggleMode}
-	class="p-2 rounded-md hover:bg-gray-700 dark:hover:bg-gray-600 transition-colors"
+	class="p-2 rounded-md hover:bg-hover transition-colors"
 	aria-label="Toggle dark mode"
 	title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}>
 	{#if isDark}

--- a/src/lib/ui/ScoreboardRow.svelte
+++ b/src/lib/ui/ScoreboardRow.svelte
@@ -64,8 +64,8 @@
 		<div role="cell" class="w-4 justify-self-center"><Logo ref={logo}/></div>
 	{/if}
 	{#if mode != 'summary'}
-		<div role="cell" class="text-nowrap overflow-hidden text-ellipsis">
-			<a href="/team/{team?.id}" class="text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">{team?.display_name || team?.name}</a>
+		<div role="cell" class="text-nowrap overflow-hidden text-ellipsis hover:bg-hover rounded">
+			<a href="/team/{team?.id}" class="text-gray-900 dark:text-gray-100 transition-colors">{team?.display_name || team?.name}</a>
 		</div>
 	{/if}
 
@@ -92,7 +92,7 @@
 					style="background-color:{scoreBg(rp, problem)}">
 					{#if scoreboard_type === 'pass-fail'}
 						<span class="@max-[30px]:hidden">{timeToMin(rp.time)}</span>
-						<span class="text-xs text-white/70 pl-0.5 @max-[60px]:hidden">{rp.num_judged + rp.num_pending}</span>
+						<span class="text-xs text-white/70 dark:text-gray-600 pl-0.5 @max-[60px]:hidden">{rp.num_judged + rp.num_pending}</span>
 					{:else if scoreboard_type === 'score'}
 						<span class="@max-[30px]:hidden">{rp.score}</span>
 						<span class="text-xs text-white/70 pl-0.5 @max-[60px]:hidden">{rp.num_judged + rp.num_pending}</span>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,13 +33,17 @@
 			</div>
 		{/if}
 
+		<div class="text-2xl w-full">{data.name}</div>
 
 		<div class="w-48"><Clock contest={data.contest} /></div>
 
+		<div class="text-lg hover:bg-hover p-2 rounded-md"><a href="/" class="flex flex-row items-center"><i class="fa-regular fa-people-group pr-2"></i>Teams</a></div>
+
 		{#if data.map}
+			<div class="text-lg hover:bg-hover p-2 rounded-md"><a href="/map" class="flex flex-row items-center"><i class="fa-regular fa-map pr-2"></i>Map</a></div>
 		{/if}
 
-		<div class="text-lg"><a href="/scoreboard" class="flex flex-row items-center"><i class="fa-solid fa-square-poll-horizontal pr-2"></i> Scoreboard</a></div>
+		<div class="text-lg hover:bg-hover p-2 rounded-md"><a href="/scoreboard" class="flex flex-row items-center"><i class="fa-regular fa-square-poll-horizontal pr-2"></i>Scoreboard</a></div>
 
 		<DarkModeToggle />
 	</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 <div
 	class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 max-h-full w-full gap-2 p-2 overflow-auto bg-white dark:bg-gray-900">
 	{#each data.teams as team, i}
-		<div class="flex flex-row items-center bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors">
+		<div class="flex flex-row items-center bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-hover transition-colors">
 			<a href="/team/{team.id}" class="w-full">
 				<div class="flex flex-row gap-2 items-center text-gray-900 dark:text-gray-100">
 					{#if data.logos[i]}
@@ -17,7 +17,7 @@
 						</div>
 					{/if}
 
-					<div class="p-1 min-w-6">{team.id}</div>
+					<div class="p-1 min-w-6">{team.label ?? team.id}</div>
 
 					<div>{team.display_name || team.name}</div>
 				</div>

--- a/src/routes/scoreboard/+page.svelte
+++ b/src/routes/scoreboard/+page.svelte
@@ -23,7 +23,7 @@
 
 	<div role="rowgroup">
 		{#each data.scoreboard.rows as row, i (row.team_id)}
-			<div animate:flip class="even:bg-white dark:even:bg-gray-800 odd:bg-gray-100 dark:odd:bg-gray-700">
+			<div animate:flip class="even:bg-white dark:even:bg-gray-900 odd:bg-gray-100 dark:odd:bg-gray-800">
 				<ScoreboardRow
 					showLogo={data.hasLogos}
 					scoreboard_type={data.scoreboard_type}


### PR DESCRIPTION
I was going to do this as two or three separate PRs, but they overlapped too much...

While testing dark mode I realized that PR #87 accidentally removed the contest name and map from the header. This adds them back, and adds a Teams button alongside them instead of having to click on the contest name to see the teams (which wasn't very obvious).

I also made some improvements/fixed some omissions in dark mode, including the scoreboard alternate row background color, and color of # of attempts.

I had also started to make the hover indication (things you can click on) consistent, mainly in the header. Instead of setting the hover color separately in every instance I found a much cleaner way to declare the light/dark colors in the Tailwind app.css, and use it with a much simpler 'hover:bg-hover'. This is how I intend to slowly pull out other 'theme colors' over time instead of having the color values used all throughout the app.

Fixes to #87, first part of #86.