### PR TITLE
chore: linting and formating

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ If you run team view in a web browser in kiosk mode, it is a direct replacement 
 Coach View (https://tools.icpc.global).
 
 But it is also much more:
+
 - A performant web app for all contest data - runs on any client and minimal load on network and backend server.
 - Fully reactive - portions of the UI appear only when content is available, so for instance, if your contest
   doesn't have video streaming or maps those options won't appear in the UI.
@@ -21,10 +22,10 @@ https://github.com/icpctools/team-view/pkgs/container/team-view
 
 To configure your backend Contest API server, set the following environment variables:
 
- - CONTEST_URL - The Contest API base URL, e.g. http://cds/api/
- - CONTEST_ID - Optional contest id, only required when more than one contest is configured.
- - CONTEST_USER - A user on the contest server.
- - CONTEST_PASSWORD - The user's password.
+- CONTEST_URL - The Contest API base URL, e.g. http://cds/api/
+- CONTEST_ID - Optional contest id, only required when more than one contest is configured.
+- CONTEST_USER - A user on the contest server.
+- CONTEST_PASSWORD - The user's password.
 
 ## Developing
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"test": "npm run test:unit && npm run test:integration",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint .",
+		"lint": "eslint .",
 		"format": "prettier --write .",
 		"test:integration": "playwright test",
 		"test:unit": "vitest"

--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -63,7 +63,7 @@ export class ContestAPI {
 
 	timeDelta = [];
 
-	interval: any;
+	interval: number | NodeJS.Timeout | undefined;
 
 	constructor(contestURL: string, credentials?: Credentials) {
 		if (!contestURL.endsWith('/')) {
@@ -121,6 +121,7 @@ export class ContestAPI {
 		return options;
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	async loadObject(type: string): Promise<any> {
 		const startTime = performance.now();
 		const url = this.getURL(type);
@@ -406,6 +407,7 @@ export class ContestAPI {
 
 	private processFileReferences(obj: unknown) {
 		// We get either one object or an array of objects, handle both cases
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		let objs: any[];
 		if (Array.isArray(obj)) {
 			objs = obj;
@@ -430,7 +432,7 @@ export class ContestAPI {
 
 	watch(): void {
 		if (this.interval) {
-			return this.interval;
+			return;
 		}
 		console.log(`Watching ${this.id}`);
 		this.interval = setInterval(async () => {

--- a/src/lib/hardcoded.svelte.ts
+++ b/src/lib/hardcoded.svelte.ts
@@ -1,8 +1,12 @@
 import { browser } from '$app/environment';
 
-export const CONTEST = $state(browser ? {} : {
-    url: process?.env?.CONTEST_URL || 'https://localhost:8443/api/',
-    contest_id: process?.env?.CONTEST_ID || undefined,
-    user: process?.env?.CONTEST_USER || 'admin',
-    password: process?.env?.CONTEST_PASSWORD || 'adm1n',
-});
+export const CONTEST = $state(
+	browser
+		? {}
+		: {
+				url: process?.env?.CONTEST_URL || 'https://localhost:8443/api/',
+				contest_id: process?.env?.CONTEST_ID || undefined,
+				user: process?.env?.CONTEST_USER || 'admin',
+				password: process?.env?.CONTEST_PASSWORD || 'adm1n'
+			}
+);

--- a/src/lib/ui/FloorMap.svelte
+++ b/src/lib/ui/FloorMap.svelte
@@ -155,7 +155,7 @@
 		}
 
 		if (mapInfo?.spare_teams) {
-			for (const l of mapInfo?.spare_teams) {
+			for (const l of mapInfo?.spare_teams ?? []) {
 				ctx.translate(l.x * scale, l.y * scale);
 
 				let rotation = ((90 - l.rotation) * Math.PI) / 180;

--- a/src/lib/ui/Problem.svelte
+++ b/src/lib/ui/Problem.svelte
@@ -30,6 +30,10 @@
 
 <!-- svelte-ignore a11y_interactive_supports_focus -->
 <!-- svelte-ignore a11y_click_events_have_key_events -->
-<div class="grid grid-row justify-self-center border-[1px] rounded-sm min-w-4 w-full max-w-12 @container dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600" role="link" style={pStyle} {onclick}>
+<div
+	class="grid grid-row justify-self-center border-[1px] rounded-sm min-w-4 w-full max-w-12 @container dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600"
+	role="link"
+	style={pStyle}
+	{onclick}>
 	<span class="text-center @max-[20px]:invisible">{problem?.label}</span>
 </div>

--- a/src/lib/ui/ScoreboardHeader.svelte
+++ b/src/lib/ui/ScoreboardHeader.svelte
@@ -16,7 +16,10 @@
 </script>
 
 <div role="rowgroup" class="sticky top-0 bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm font-semibold">
-	<div role="row" class="grid grid-table gap-x-0.5 min-h-7 py-2 text-gray-900 dark:text-gray-100" style="grid-template-columns: {col}">
+	<div
+		role="row"
+		class="grid grid-table gap-x-0.5 min-h-7 py-2 text-gray-900 dark:text-gray-100"
+		style="grid-template-columns: {col}">
 		<div role="cell">Rank</div>
 		{#if showLogo}
 			<div role="cell"></div>
@@ -30,7 +33,11 @@
 		{/if}
 		{#each problems as problem}
 			<div role="cell" class="justify-self-center w-3/4">
-				<Problem {problem} onclick={() => { goto('/problem/' + problem.id)}}/>
+				<Problem
+					{problem}
+					onclick={() => {
+						goto('/problem/' + problem.id);
+					}} />
 			</div>
 		{/each}
 	</div>

--- a/src/lib/ui/ScoreboardRow.svelte
+++ b/src/lib/ui/ScoreboardRow.svelte
@@ -93,7 +93,8 @@
 					style="background-color:{scoreBg(rp, problem)}">
 					{#if scoreboard_type === 'pass-fail'}
 						<span class="@max-[30px]:hidden">{timeToMin(rp.time)}</span>
-						<span class="text-xs text-white/70 dark:text-gray-600 pl-0.5 @max-[60px]:hidden">{rp.num_judged + rp.num_pending}</span>
+						<span class="text-xs text-white/70 dark:text-gray-600 pl-0.5 @max-[60px]:hidden"
+							>{rp.num_judged + rp.num_pending}</span>
 					{:else if scoreboard_type === 'score'}
 						<span class="@max-[30px]:hidden">{rp.score}</span>
 						<span class="text-xs text-white/70 pl-0.5 @max-[60px]:hidden">{rp.num_judged + rp.num_pending}</span>

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -37,14 +37,20 @@
 		<div class="flex flex-col">
 			<div class="text-xl">Submissions ({data.submissions.length})</div>
 
-			<div class="grid grid-table bg-gray-100 dark:bg-gray-800" style="grid-template-columns: 1fr 1fr 1fr 1fr" role="row">
+			<div
+				class="grid grid-table bg-gray-100 dark:bg-gray-800"
+				style="grid-template-columns: 1fr 1fr 1fr 1fr"
+				role="row">
 				<div role="cell" class="p-2 font-semibold">Time</div>
 				<div role="cell" class="p-2 font-semibold">Team</div>
 				<div role="cell" class="p-2 font-semibold">Language</div>
 				<div role="cell" class="p-2 font-semibold">Judgement</div>
 			</div>
 			{#each data.submissions as submission}
-				<div class="grid grid-table even:bg-white dark:even:bg-gray-900 odd:bg-gray-50 dark:odd:bg-gray-800" style="grid-template-columns: 1fr 1fr 1fr 1fr" role="row">
+				<div
+					class="grid grid-table even:bg-white dark:even:bg-gray-900 odd:bg-gray-50 dark:odd:bg-gray-800"
+					style="grid-template-columns: 1fr 1fr 1fr 1fr"
+					role="row">
 					<div role="cell" class="p-2">{submission.time}</div>
 					<div role="cell" class="p-2">
 						<a href="/team/{submission.team?.id}" class="text-blue-600 dark:text-blue-400 hover:underline"

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -77,7 +77,7 @@
 				<div class="grid grid-table" style="grid-template-columns: 1fr 1fr 1fr 1fr" role="row">
 					<div role="cell" class="">{submission.time}</div>
 					<div role="cell" class="">
-						<Problem problem={submission.problem} onclick={() => goto('/problem/' + submission.problem?.id)}/>
+						<Problem problem={submission.problem} onclick={() => goto('/problem/' + submission.problem?.id)} />
 					</div>
 					<div role="cell" class="">{submission.language}</div>
 					<div role="cell" class="">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ function excludeNodeModules(): Plugin {
 	return {
 		name: 'exclude-node-modules',
 		enforce: 'pre',
-		resolveId(id, importer) {
+		resolveId(id) {
 			// Don't resolve Node.js-only packages for client builds
 			if (
 				id === 'got' ||


### PR DESCRIPTION
Cleanly splits lint (eslint) and format (prettier) in package.json so that they're independant.

All other changes are applying the remaining lint fixes (contest-api.ts, FloorMap.svelte, and vite.config.ts) and formatting (all other files) so that `pnpm lint` and `pnpm format` run without errors.

Part of #95.