### PR TITLE
chore: fix unit tests and add to build

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Run build
         run: pnpm build
+
+      - name: Run unit tests
+        run: pnpm test:unit

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
 		"eslint-config-prettier": "^9.1.2",
 		"eslint-plugin-svelte": "^2.46.1",
 		"globals": "^15.15.0",
-		"msw": "^2.12.9",
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.4.1",
 		"svelte": "^5.49.2",

--- a/packages/contest-api/package.json
+++ b/packages/contest-api/package.json
@@ -26,7 +26,6 @@
 	},
 	"devDependencies": {
 		"@types/node": "^24.6.2",
-		"msw": "^2.12.4",
 		"typescript": "^5.9.3",
 		"vitest": "^2.1.9"
 	}

--- a/packages/contest-api/src/contest-api.test.ts
+++ b/packages/contest-api/src/contest-api.test.ts
@@ -1,48 +1,62 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { ContestAPI } from './contest-api';
-import { setupServer, type SetupServerApi } from 'msw/node';
-import { http, HttpResponse } from 'msw';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import type { Response } from 'got';
 
-class TestContestAPI extends ContestAPI {
-	id: string;
-
-	constructor(id: string) {
-		super(`https://apiServer.org/api/contests/${id}`);
-		this.id = id;
-
-		server = setupServer(
-			http.get(`https://apiServer.org/api/contests/${id}/*`, (x) => {
-				const ind = x.request.url.lastIndexOf('/');
-				const type = x.request.url.substring(ind + 1);
-				const file = this.getFile(type);
-				return HttpResponse.json(JSON.parse(file));
-			})
-		);
-		server.listen({ onUnhandledRequest: 'error' });
-	}
-
-	getFile(type: string): string {
-		// use contest.json for the root
-		const filename = type ? type : 'contest';
-		const filePath = resolve(`tests/contests/${this.id}/${filename}.json`);
-		return readFileSync(filePath, 'utf8');
-	}
+function getFile(contestId: string, type: string): string {
+	// use contest.json for the root
+	const filename = type ? type : 'contest';
+	// Path is relative to workspace root, not package root
+	const filePath = resolve(`tests/contests/${contestId}/${filename}.json`);
+	return readFileSync(filePath, 'utf8');
 }
 
-let server: SetupServerApi | undefined = undefined;
+// Mock got module
+vi.mock('got', () => {
+	return {
+		default: vi.fn((url: string) => {
+			// Extract contest ID and type from URL
+			const urlObj = new URL(url);
+			const pathParts = urlObj.pathname.split('/').filter(Boolean);
+			const contestsIndex = pathParts.indexOf('contests');
+			const contestId = pathParts[contestsIndex + 1];
+			const type = pathParts[contestsIndex + 2] || '';
+
+			const file = getFile(contestId, type);
+
+			return Promise.resolve({
+				body: file,
+				statusCode: 200
+			} as Response);
+		}),
+		HTTPError: class HTTPError extends Error {
+			response: { statusCode: number; statusMessage: string };
+			constructor(response: { statusCode: number; statusMessage: string }) {
+				super();
+				this.response = response;
+			}
+		},
+		RequestError: class RequestError extends Error {
+			code: string;
+			constructor(code: string) {
+				super();
+				this.code = code;
+			}
+		}
+	};
+});
 
 beforeEach(() => {
 	vi.clearAllMocks();
 });
 
 afterEach(() => {
-	server?.close();
+	// Cleanup if needed
 });
 
 test('load contest', async () => {
-	const contestAPI = new TestContestAPI('basic');
+	const contestAPI = new ContestAPI('https://apiServer.org/api/contests/basic');
 
 	await contestAPI.loadContest();
 	const contest = contestAPI.getContest();
@@ -51,7 +65,7 @@ test('load contest', async () => {
 });
 
 test('load groups', async () => {
-	const contestAPI = new TestContestAPI('basic');
+	const contestAPI = new ContestAPI('https://apiServer.org/api/contests/basic');
 
 	await contestAPI.loadGroups();
 	const groups = contestAPI.getGroups();

--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -126,7 +126,7 @@ export class ContestAPI {
 		const startTime = performance.now();
 		const url = this.getURL(type);
 		try {
-			const response = await got.get(url, this.getHttpOptions());
+			const response = await got(url, this.getHttpOptions());
 			const obj = JSON.parse(response.body);
 			const endTime = performance.now();
 			console.log(`Fetched ${url} in ${(endTime - startTime).toFixed(1)}ms`);

--- a/packages/contest-api/vitest.config.ts
+++ b/packages/contest-api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node'
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,6 @@ importers:
       globals:
         specifier: ^15.15.0
         version: 15.15.0
-      msw:
-        specifier: ^2.12.9
-        version: 2.12.9(@types/node@24.10.11)(typescript@5.9.3)
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -109,15 +106,12 @@ importers:
       '@types/node':
         specifier: ^24.6.2
         version: 24.6.2
-      msw:
-        specifier: ^2.12.4
-        version: 2.12.4(@types/node@24.6.2)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.6.2)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.6.2)(typescript@5.9.3))
+        version: 2.1.9(@types/node@24.6.2)(lightningcss@1.30.2)(msw@2.12.9(@types/node@24.6.2)(typescript@5.9.3))
 
 packages:
 
@@ -530,10 +524,6 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
-
-  '@mswjs/interceptors@0.40.0':
-    resolution: {integrity: sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==}
-    engines: {node: '>=18'}
 
   '@mswjs/interceptors@0.41.2':
     resolution: {integrity: sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw==}
@@ -1637,16 +1627,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.12.4:
-    resolution: {integrity: sha512-rHNiVfTyKhzc0EjoXUBVGteNKBevdjOlVC6GlIRXpy+/3LHEIGRovnB5WPjcvmNODVQ1TNFnoa7wsGbd0V3epg==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>= 4.8.x'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   msw@2.12.9:
     resolution: {integrity: sha512-NYbi51C6M3dujGmcmuGemu68jy12KqQPoVWGeroKToLGsBgrwG5ErM8WctoIIg49/EV49SEvYM9WSqO4G7kNeQ==}
     engines: {node: '>=18'}
@@ -1837,9 +1817,6 @@ packages:
   rettime@0.10.1:
     resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
-  rettime@0.7.0:
-    resolution: {integrity: sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==}
-
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2014,10 +1991,6 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
-
-  type-fest@5.3.1:
-    resolution: {integrity: sha512-VCn+LMHbd4t6sF3wfU/+HKT63C9OoyrSIf4b+vtWHpt2U7/4InZG467YDNMFMR70DdHjAdpPWmw2lzRdg0Xqqg==}
-    engines: {node: '>=20'}
 
   type-fest@5.4.3:
     resolution: {integrity: sha512-AXSAQJu79WGc79/3e9/CR77I/KQgeY1AhNvcShIH4PTcGYyC4xv6H4R4AUOwkPS5799KlVDAu8zExeCrkGquiA==}
@@ -2448,7 +2421,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/ansi@1.0.2': {}
+  '@inquirer/ansi@1.0.2':
+    optional: true
 
   '@inquirer/confirm@5.1.21(@types/node@24.10.11)':
     dependencies:
@@ -2456,6 +2430,7 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@24.10.11)
     optionalDependencies:
       '@types/node': 24.10.11
+    optional: true
 
   '@inquirer/confirm@5.1.21(@types/node@24.6.2)':
     dependencies:
@@ -2463,6 +2438,7 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@24.6.2)
     optionalDependencies:
       '@types/node': 24.6.2
+    optional: true
 
   '@inquirer/core@10.3.2(@types/node@24.10.11)':
     dependencies:
@@ -2476,6 +2452,7 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 24.10.11
+    optional: true
 
   '@inquirer/core@10.3.2(@types/node@24.6.2)':
     dependencies:
@@ -2489,16 +2466,20 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 24.6.2
+    optional: true
 
-  '@inquirer/figures@1.0.15': {}
+  '@inquirer/figures@1.0.15':
+    optional: true
 
   '@inquirer/type@3.0.10(@types/node@24.10.11)':
     optionalDependencies:
       '@types/node': 24.10.11
+    optional: true
 
   '@inquirer/type@3.0.10(@types/node@24.6.2)':
     optionalDependencies:
       '@types/node': 24.6.2
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2521,15 +2502,6 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@mswjs/interceptors@0.40.0':
-    dependencies:
-      '@open-draft/deferred-promise': 2.2.0
-      '@open-draft/logger': 0.3.0
-      '@open-draft/until': 2.1.0
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      strict-event-emitter: 0.5.1
-
   '@mswjs/interceptors@0.41.2':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -2538,15 +2510,19 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+    optional: true
 
-  '@open-draft/deferred-promise@2.2.0': {}
+  '@open-draft/deferred-promise@2.2.0':
+    optional: true
 
   '@open-draft/logger@0.3.0':
     dependencies:
       is-node-process: 1.2.0
       outvariant: 1.4.3
+    optional: true
 
-  '@open-draft/until@2.1.0': {}
+  '@open-draft/until@2.1.0':
+    optional: true
 
   '@playwright/test@1.58.2':
     dependencies:
@@ -2825,7 +2801,8 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
-  '@types/statuses@2.0.6': {}
+  '@types/statuses@2.0.6':
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -2947,15 +2924,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(msw@2.12.4(@types/node@24.6.2)(typescript@5.9.3))(vite@5.4.21(@types/node@24.6.2)(lightningcss@1.30.2))':
-    dependencies:
-      '@vitest/spy': 2.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.19
-    optionalDependencies:
-      msw: 2.12.4(@types/node@24.6.2)(typescript@5.9.3)
-      vite: 5.4.21(@types/node@24.6.2)(lightningcss@1.30.2)
-
   '@vitest/mocker@2.1.9(msw@2.12.9(@types/node@24.10.11)(typescript@5.9.3))(vite@5.4.21(@types/node@24.10.11)(lightningcss@1.30.2))':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -2964,6 +2932,15 @@ snapshots:
     optionalDependencies:
       msw: 2.12.9(@types/node@24.10.11)(typescript@5.9.3)
       vite: 5.4.21(@types/node@24.10.11)(lightningcss@1.30.2)
+
+  '@vitest/mocker@2.1.9(msw@2.12.9(@types/node@24.6.2)(typescript@5.9.3))(vite@5.4.21(@types/node@24.6.2)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      msw: 2.12.9(@types/node@24.6.2)(typescript@5.9.3)
+      vite: 5.4.21(@types/node@24.6.2)(lightningcss@1.30.2)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -3012,7 +2989,8 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ansi-regex@5.0.1: {}
+  ansi-regex@5.0.1:
+    optional: true
 
   ansi-styles@4.3.0:
     dependencies:
@@ -3084,13 +3062,15 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  cli-width@4.1.0: {}
+  cli-width@4.1.0:
+    optional: true
 
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+    optional: true
 
   clsx@2.1.1: {}
 
@@ -3106,7 +3086,8 @@ snapshots:
 
   cookie@0.6.0: {}
 
-  cookie@1.1.1: {}
+  cookie@1.1.1:
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3144,7 +3125,8 @@ snapshots:
 
   dom-walk@0.1.2: {}
 
-  emoji-regex@8.0.0: {}
+  emoji-regex@8.0.0:
+    optional: true
 
   enhanced-resolve@5.19.0:
     dependencies:
@@ -3210,7 +3192,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
-  escalade@3.2.0: {}
+  escalade@3.2.0:
+    optional: true
 
   escape-string-regexp@4.0.0: {}
 
@@ -3371,7 +3354,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  get-caller-file@2.0.5: {}
+  get-caller-file@2.0.5:
+    optional: true
 
   get-stream@9.0.1:
     dependencies:
@@ -3422,7 +3406,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphql@16.12.0: {}
+  graphql@16.12.0:
+    optional: true
 
   has-flag@4.0.0: {}
 
@@ -3430,7 +3415,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  headers-polyfill@4.0.3: {}
+  headers-polyfill@4.0.3:
+    optional: true
 
   http-cache-semantics@4.2.0: {}
 
@@ -3462,7 +3448,8 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
-  is-fullwidth-code-point@3.0.0: {}
+  is-fullwidth-code-point@3.0.0:
+    optional: true
 
   is-function@1.0.2: {}
 
@@ -3472,7 +3459,8 @@ snapshots:
 
   is-module@1.0.0: {}
 
-  is-node-process@1.2.0: {}
+  is-node-process@1.2.0:
+    optional: true
 
   is-reference@1.2.1:
     dependencies:
@@ -3632,31 +3620,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.4(@types/node@24.6.2)(typescript@5.9.3):
-    dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@24.6.2)
-      '@mswjs/interceptors': 0.40.0
-      '@open-draft/deferred-promise': 2.2.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.12.0
-      headers-polyfill: 4.0.3
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.7.0
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.0
-      type-fest: 5.3.1
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-
   msw@2.12.9(@types/node@24.10.11)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@24.10.11)
@@ -3681,8 +3644,36 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
-  mute-stream@2.0.0: {}
+  msw@2.12.9(@types/node@24.6.2)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@24.6.2)
+      '@mswjs/interceptors': 0.41.2
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.4.3
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  mute-stream@2.0.0:
+    optional: true
 
   mux.js@7.1.0:
     dependencies:
@@ -3706,7 +3697,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  outvariant@1.4.3: {}
+  outvariant@1.4.3:
+    optional: true
 
   p-cancelable@4.0.1: {}
 
@@ -3728,7 +3720,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-to-regexp@6.3.0: {}
+  path-to-regexp@6.3.0:
+    optional: true
 
   pathe@1.1.2: {}
 
@@ -3793,7 +3786,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  require-directory@2.1.1: {}
+  require-directory@2.1.1:
+    optional: true
 
   resolve-alpn@1.2.1: {}
 
@@ -3813,9 +3807,8 @@ snapshots:
     dependencies:
       lowercase-keys: 3.0.0
 
-  rettime@0.10.1: {}
-
-  rettime@0.7.0: {}
+  rettime@0.10.1:
+    optional: true
 
   rollup@4.57.1:
     dependencies:
@@ -3874,7 +3867,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@4.1.0: {}
+  signal-exit@4.1.0:
+    optional: true
 
   sirv@3.0.2:
     dependencies:
@@ -3886,21 +3880,25 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  statuses@2.0.2: {}
+  statuses@2.0.2:
+    optional: true
 
   std-env@3.9.0: {}
 
-  strict-event-emitter@0.5.1: {}
+  strict-event-emitter@0.5.1:
+    optional: true
 
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+    optional: true
 
   strip-json-comments@3.1.1: {}
 
@@ -3961,7 +3959,8 @@ snapshots:
       magic-string: 0.30.21
       zimmerframe: 1.1.4
 
-  tagged-tag@1.0.0: {}
+  tagged-tag@1.0.0:
+    optional: true
 
   tailwindcss@4.1.18: {}
 
@@ -3982,17 +3981,20 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
-  tldts-core@7.0.19: {}
+  tldts-core@7.0.19:
+    optional: true
 
   tldts@7.0.19:
     dependencies:
       tldts-core: 7.0.19
+    optional: true
 
   totalist@3.0.1: {}
 
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.19
+    optional: true
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -4004,13 +4006,10 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  type-fest@5.3.1:
-    dependencies:
-      tagged-tag: 1.0.0
-
   type-fest@5.4.3:
     dependencies:
       tagged-tag: 1.0.0
+    optional: true
 
   typescript-eslint@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -4029,7 +4028,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  until-async@3.0.2: {}
+  until-async@3.0.2:
+    optional: true
 
   uri-js@4.4.1:
     dependencies:
@@ -4178,10 +4178,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@24.6.2)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.6.2)(typescript@5.9.3)):
+  vitest@2.1.9(@types/node@24.6.2)(lightningcss@1.30.2)(msw@2.12.9(@types/node@24.6.2)(typescript@5.9.3)):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.12.4(@types/node@24.6.2)(typescript@5.9.3))(vite@5.4.21(@types/node@24.6.2)(lightningcss@1.30.2))
+      '@vitest/mocker': 2.1.9(msw@2.12.9(@types/node@24.6.2)(typescript@5.9.3))(vite@5.4.21(@types/node@24.6.2)(lightningcss@1.30.2))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -4231,21 +4231,25 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+    optional: true
 
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+    optional: true
 
-  y18n@5.0.8: {}
+  y18n@5.0.8:
+    optional: true
 
   yaml@1.10.2: {}
 
   yaml@2.7.0:
     optional: true
 
-  yargs-parser@21.1.1: {}
+  yargs-parser@21.1.1:
+    optional: true
 
   yargs@17.7.2:
     dependencies:
@@ -4256,9 +4260,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    optional: true
 
   yocto-queue@0.1.0: {}
 
-  yoctocolors-cjs@2.1.3: {}
+  yoctocolors-cjs@2.1.3:
+    optional: true
 
   zimmerframe@1.1.4: {}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,7 @@ function excludeNodeModules(): Plugin {
 export default defineConfig({
 	plugins: [excludeNodeModules(), tailwindcss(), sveltekit()],
 	test: {
-		include: ['src/**/*.{test,spec}.{js,ts}']
+		include: ['src/**/*.{test,spec}.{js,ts}', 'packages/**/*.{test,spec}.{js,ts}']
 	},
 	ssr: {
 		noExternal: ['contest-api']


### PR DESCRIPTION
The unit tests have been broken (and not even running) since I moved the contest api to a package, and of course I didn't even notice right away.

Of course that problem was introduced by trying a new AI IDE to help with the packaging (which never checked the tests), and I used a different one to help fix. :) Interestingly it preferred mocking the got package over using the msw package, so I've removed that dependency.

vite.config.ts adds the new path to test; vitest.config.ts ensures it is run as a node package.

I also added the unit tests to the PR check so that this won't happen again. We need lots more tests though (!).

Fixes #90.