### PR TITLE
feat: added missing hover indicators

### DIFF
--- a/src/lib/ui/JudgementType.svelte
+++ b/src/lib/ui/JudgementType.svelte
@@ -10,7 +10,7 @@
 
 {#if judgement_type}
 	<div
-		class="justify-self-center text-center text-sm text-white rounded-sm w-10"
+		class="justify-self-center text-center text-sm text-white rounded-sm w-10 cursor-default"
 		class:bg-green-600={judgement_type.solved}
 		class:bg-red-600={judgement_type.penalty}
 		class:bg-cyan-600={!judgement_type.solved && !judgement_type.penalty}>

--- a/src/lib/ui/Problem.svelte
+++ b/src/lib/ui/Problem.svelte
@@ -11,30 +11,34 @@
 
 	let pStyle = $derived.by(() => {
 		const rgb = problem?.rgb;
-		if (rgb) {
-			let col = parseHexColor(rgb);
-			let fg = '#fff';
-			if (col && col[0] + col[1] + col[2] > 450) {
-				fg = '#000';
-			}
-			let border = rgb;
-			if (col) {
-				border = rgbToHex(darker(col));
-			}
-
-			return 'background-color:' + rgb + ';color:' + fg + ';border-color:' + border + ';';
-		} else {
-			return 'background-color:#fff;color:#000;border:#000;';
+		if (!rgb) {
+			return 'color:#000;border-color:#000';
 		}
+
+		let col = parseHexColor(rgb);
+		let fg = '#fff';
+		if (col && col[0] + col[1] + col[2] > 450) {
+			fg = '#000';
+		}
+		let border = rgb;
+		if (col) {
+			border = rgbToHex(darker(col));
+		}
+
+		return 'color:' + fg + ';border-color:' + border;
 	});
 </script>
 
 <!-- svelte-ignore a11y_interactive_supports_focus -->
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
-	class="grid grid-row justify-self-center border-[1px] rounded-sm min-w-4 w-full max-w-12 @container dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600"
+	class="grid grid-row justify-self-center border rounded-sm min-w-4 w-full max-w-12 @container dark:text-gray-100"
+	class:hover:bg-hover={onclick}
+	class:cursor-pointer={onclick}
+	class:cursor-default={!onclick}
+	class:bg-[var(--problem-bg)]={true}
 	role="link"
-	style={pStyle}
+	style="{pStyle};--problem-bg:{problem?.rgb ?? '#fff'}"
 	{onclick}>
 	<span class="text-center @max-[20px]:invisible">{problem?.label}</span>
 </div>

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -53,7 +53,7 @@
 					role="row">
 					<div role="cell" class="p-2">{submission.time}</div>
 					<div role="cell" class="p-2">
-						<a href="/team/{submission.team?.id}" class="text-blue-600 dark:text-blue-400 hover:underline"
+						<a href="/team/{submission.team?.id}" class="text-blue-600 dark:text-blue-400 hover:bg-hover p-1 rounded"
 							>{submission.team?.label}: {submission.team?.display_name || submission.team?.name}</a>
 					</div>
 					<div role="cell" class="p-2">{submission.language}</div>


### PR DESCRIPTION
Added cursor-default to non-clickable JudgementType and Problem so that the cursor doesn't change to text cursor when hovering.

When Problems are clickable, I changed the cursor and added hover bg. This required using a slightly different style trick to make it dynamic.

Added hover to teams on the problem page so that they're consistent and you can tell you can click on them.

Fixes #86.