### PR TITLE
chore: update module properties

### DIFF
--- a/packages/contest-api/tsconfig.json
+++ b/packages/contest-api/tsconfig.json
@@ -1,9 +1,9 @@
 {
 	"compilerOptions": {
-		"module": "esnext",
+		"module": "nodenext",
 		"target": "esnext",
 		"sourceMap": false,
-		"moduleResolution": "bundler",
+		"moduleResolution": "nodenext",
 		"strict": true,
 		"allowSyntheticDefaultImports": true,
 		"isolatedModules": true,


### PR DESCRIPTION
Caught this on an unrelated project - tsconfig should have different options for the contest api package since the module will be used by both node and javascript/ browser clients:
https://stackoverflow.com/questions/78085423/which-typescript-module-settings-for-a-library-that-is-used-in-browsers-and-node/78087127#78087127

Switching to the recommended options, which don't appear to cause any immediate impact.