### PR TITLE
feat: contest util for getting file by tag, access

### DIFF
--- a/packages/contest-api/src/contest-util.test.ts
+++ b/packages/contest-api/src/contest-util.test.ts
@@ -1,0 +1,109 @@
+import { expect, test } from 'vitest';
+import { ContestUtil } from './contest-util';
+import { Access, FileReference, Problem } from './contest-types';
+
+const util = new ContestUtil();
+
+test('getOppositeTag', () => {
+	expect(util.getOppositeTag('light')).toBe('dark');
+	expect(util.getOppositeTag('dark')).toBe('light');
+	expect(util.getOppositeTag('sam')).toBeUndefined();
+});
+
+test('getFileByTag', () => {
+	const file1 = {
+		href: 'href',
+		filename: 'name',
+		mime: 'mime',
+		tags: ['a', 'b']
+	} as FileReference;
+	const file2 = {
+		href: 'href',
+		filename: 'name',
+		mime: 'mime',
+		tags: ['c', 'd']
+	} as FileReference;
+	const file3 = {
+		href: 'href',
+		filename: 'name',
+		mime: 'mime'
+		// no tags
+	} as FileReference;
+
+	const files = [file1, file2, file3] as FileReference[];
+
+	expect(util.getFileByTag(files, 'a')).toEqual(file1);
+	expect(util.getFileByTag(files, 'b')).toEqual(file1);
+	expect(util.getFileByTag(files, 'c')).toEqual(file2);
+	expect(util.getFileByTag(files, 'd')).toEqual(file2);
+	expect(util.getFileByTag(files, 'e')).toBeUndefined();
+	expect(util.getFileByTag(undefined, 'b')).toBeUndefined();
+});
+
+test('hasEndpoint', () => {
+	const access = {
+		capabilities: [],
+		endpoints: [
+			{
+				type: 'a',
+				properties: []
+			}
+		]
+	} as Access;
+
+	expect(util.hasEndpoint(access, 'a')).toBeTruthy();
+	expect(util.hasEndpoint(access, 'b')).toBeFalsy();
+	expect(util.hasEndpoint(undefined, 'b')).toBeFalsy();
+});
+
+test('hasEndpointProperty', () => {
+	const access = {
+		capabilities: [],
+		endpoints: [
+			{
+				type: 'a',
+				properties: ['b', 'c']
+			}
+		]
+	} as Access;
+
+	expect(util.hasEndpointProperty(access, 'a', 'b')).toBeTruthy();
+	expect(util.hasEndpointProperty(access, 'a', 'c')).toBeTruthy();
+	expect(util.hasEndpointProperty(access, 'a', 'd')).toBeFalsy();
+	expect(util.hasEndpointProperty(access, 'x', 'b')).toBeFalsy();
+	expect(util.hasEndpointProperty(undefined, 'x', 'b')).toBeFalsy();
+});
+
+test('sortProblems', () => {
+	const problems = [
+		{
+			id: 'c',
+			label: 'C',
+			name: 'C problem',
+			ordinal: 2,
+			statement: []
+		},
+		{
+			id: 'a',
+			label: 'A',
+			name: 'A problem',
+			ordinal: 0,
+			statement: []
+		},
+		{
+			id: 'b',
+			label: 'B',
+			name: 'B problem',
+			ordinal: 1,
+			statement: []
+		}
+	] as Problem[];
+
+	const problems2 = util.sortProblems(problems);
+	expect(problems2[0].ordinal).toBe(0);
+	expect(problems2[0].id).toBe('a');
+	expect(problems2[1].ordinal).toBe(1);
+	expect(problems2[1].id).toBe('b');
+	expect(problems2[2].ordinal).toBe(2);
+	expect(problems2[2].id).toBe('c');
+});

--- a/packages/contest-api/src/contest-util.ts
+++ b/packages/contest-api/src/contest-util.ts
@@ -3,7 +3,7 @@
  */
 import type { ContestAPI } from './contest-api';
 import { parseRelTime } from './contest-time-util';
-import type { FileReference, Problem, Submission } from './contest-types';
+import type { Access, FileReference, Problem, Submission } from './contest-types';
 
 export class ContestUtil {
 	findById<Type extends { id: string }>(arr: Array<Type> | undefined, id: string | undefined): Type | undefined {
@@ -56,8 +56,34 @@ export class ContestUtil {
 	}
 
 	getOppositeTag(tag: string): string | undefined {
-		if ('light' === tag) return 'dark';
-		else if ('dark' === tag) return 'light';
+		if ('light' === tag) {
+			return 'dark';
+		} else if ('dark' === tag) {
+			return 'light';
+		}
+		return undefined;
+	}
+
+	getFileByTag(files: FileReference[] | undefined, tag: string): FileReference | undefined {
+		if (!files || files.length == 0) {
+			return undefined;
+		}
+
+		if (files.length === 1) {
+			return files[0];
+		}
+
+		// look for a file that has the given tag
+		for (const file of files) {
+			if (file.tags) {
+				for (const tag2 of file.tags) {
+					if (tag2 === tag) {
+						return file;
+					}
+				}
+			}
+		}
+
 		return undefined;
 	}
 
@@ -162,7 +188,38 @@ export class ContestUtil {
 		return false;
 	}
 
-	sortProblems(problems: Problem[]): unknown {
+	sortProblems(problems: Problem[]): Problem[] {
 		return problems.sort((a, b) => (a.ordinal > b.ordinal ? 1 : b.ordinal > a.ordinal ? -1 : 0));
+	}
+
+	hasEndpoint(acc: Access | undefined, endpoint: string): boolean {
+		if (!acc || !acc.endpoints || !endpoint) {
+			return false;
+		}
+
+		for (const ep of acc.endpoints) {
+			if (endpoint === ep.type) return true;
+		}
+
+		return false;
+	}
+
+	hasEndpointProperty(acc: Access | undefined, endpoint: string, property: string): boolean {
+		if (!acc || !acc.endpoints || !endpoint || !property) {
+			return false;
+		}
+
+		for (const ep of acc.endpoints) {
+			if (endpoint === ep.type) {
+				for (const p of ep.properties) {
+					if (property === p) {
+						return true;
+					}
+				}
+				return false;
+			}
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
Adds contest utility functions for:
- getting the first file reference with a given tag
- confirming if the access endpoint shows that a given endpoint exists
- or that an endpoint has a property (e.g. does this contest have reaction videos? util.hasEndpointProperty(access, 'submissions','reaction'))

Tests are added for all three functions, plus some bonus tests for the existing getOppositeTag and sortProblems functions.