### PR TITLE
feat: reaction videos

### DIFF
--- a/src/lib/ui/Modal.svelte
+++ b/src/lib/ui/Modal.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		title?: string;
+		children?: Snippet;
+	}
+
+	let { title = '', children }: Props = $props();
+
+	let show = $state(false);
+	let modal = $state<HTMLDivElement>();
+
+	export function open(newTitle?: string) {
+		if (newTitle) {
+			title = newTitle;
+		}
+		show = true;
+	}
+
+	function close() {
+		show = false;
+	}
+
+	function keydown(e: KeyboardEvent): void {
+		if (e.key === 'Escape') {
+			close();
+			return;
+		}
+	}
+
+	function mousedown(e: MouseEvent): void {
+		// if the user clicked outside the modal, close it
+		if (show && e.target instanceof Node && e.target !== modal && !modal?.contains(e.target)) {
+			close();
+		}
+	}
+</script>
+
+<svelte:window on:keydown={keydown} on:mousedown={mousedown} />
+
+{#if show}
+	<div class="fixed inset-0 z-50 flex items-center justify-center">
+		<!-- Overlay -->
+		<div class="absolute inset-0 bg-black opacity-60"></div>
+
+		<!-- Modal -->
+		<div
+			bind:this={modal}
+			class="relative z-10
+					bg-white dark:bg-black
+					border border-gray-200 dark:border-gray-400 rounded-t-lg shadow-xl
+					w-[90vw] max-w-[90vw]
+					max-h-[90vh]
+					flex flex-col"
+			role="dialog">
+			<!-- Header -->
+			<div class="flex flex-row items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-400">
+				<div class="font-semibold text-black dark:text-white">
+					{title}
+				</div>
+				<button onclick={close} class="hover:bg-hover p-1 rounded" aria-label="close"
+					><i class="fa-solid fa-xmark"></i></button>
+			</div>
+
+			<!-- Content -->
+			<div class="max-w-full max-h-full inset-0 overflow-hidden">
+				{@render children?.()}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/ui/ReactionModal.svelte
+++ b/src/lib/ui/ReactionModal.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import Modal from './Modal.svelte';
+	import type { FileReference } from 'contest-api';
+	import Video from './Video.svelte';
+
+	let modal = $state<Modal>();
+	let reaction = $state<FileReference[]>();
+
+	export function openReaction(reaction2: FileReference[] | undefined, title: string) {
+		if (!reaction2) return;
+
+		reaction = reaction2;
+		modal?.open(title);
+	}
+</script>
+
+<Modal bind:this={modal}>
+	{#if reaction?.length === 1}
+		<div class="flex w-full h-full bg-black place-content-center">
+			<Video ref={reaction[0]} type="reaction" />
+		</div>
+	{:else if reaction?.length === 2}
+		<div class="flex w-full h-full bg-black">
+			<div class="flex w-1/2 h-full place-content-center">
+				<Video ref={reaction[0]} type="reaction" />
+			</div>
+			<div class="flex w-1/2 h-full place-content-center">
+				<Video ref={reaction[1]} type="reaction" />
+			</div>
+		</div>
+	{/if}
+</Modal>

--- a/src/lib/ui/Video.svelte
+++ b/src/lib/ui/Video.svelte
@@ -23,7 +23,8 @@
 		autoplay: true,
 		controls: false,
 		responsive: true,
-		fluid: false,
+		fluid: true,
+		aspectRatio: '16:9',
 		poster: '/images/icpc-logo.png',
 		preload: 'auto',
 		mpegtsjs: {

--- a/src/routes/problem/[id]/+page.server.ts
+++ b/src/routes/problem/[id]/+page.server.ts
@@ -9,6 +9,7 @@ export const load = async ({ params, depends }) => {
 	if (!cc) throw error(404);
 
 	await Promise.all([
+		cc.loadAccess(),
 		cc.loadTeams(),
 		cc.loadLanguages(),
 		cc.loadProblems(),
@@ -51,16 +52,19 @@ export const load = async ({ params, depends }) => {
 			if (j.score != undefined) judge += j.score + '';
 		}
 		return {
+			id: s.id,
 			time: timeToMin(s.contest_time),
 			team: util.findById(teams, s.team_id),
 			language: util.findById(languages, s.language_id)?.name,
 			judgement: judge,
-			judgement_type: jt
+			judgement_type: jt,
+			reaction: s.reaction
 		};
 	});
 
 	return {
 		problem: problem,
-		submissions: submissionData
+		submissions: submissionData,
+		hasReactions: util.hasEndpointProperty(cc.getAccess(), 'submissions', 'reaction')
 	};
 };

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -3,8 +3,11 @@
 	import JudgementType from '$lib/ui/JudgementType.svelte';
 	import Problem from '$lib/ui/Problem.svelte';
 	import { onMount } from 'svelte';
+	import ReactionModal from '$lib/ui/ReactionModal.svelte';
 
 	let { data } = $props();
+
+	let modal = $state<ReactionModal>();
 
 	onMount(() => {
 		const interval = setInterval(() => {
@@ -39,17 +42,20 @@
 
 			<div
 				class="grid grid-table bg-gray-100 dark:bg-gray-800"
-				style="grid-template-columns: 1fr 1fr 1fr 1fr"
+				style="grid-template-columns: 1fr 1fr 1fr 1fr 1fr"
 				role="row">
 				<div role="cell" class="p-2 font-semibold">Time</div>
 				<div role="cell" class="p-2 font-semibold">Team</div>
 				<div role="cell" class="p-2 font-semibold">Language</div>
 				<div role="cell" class="p-2 font-semibold">Judgement</div>
+				{#if data.hasReactions}
+					<div role="cell" class="p-2 font-semibold">Reaction Video</div>
+				{/if}
 			</div>
 			{#each data.submissions as submission}
 				<div
 					class="grid grid-table even:bg-white dark:even:bg-gray-900 odd:bg-gray-50 dark:odd:bg-gray-800"
-					style="grid-template-columns: 1fr 1fr 1fr 1fr"
+					style="grid-template-columns: 1fr 1fr 1fr 1fr 1fr"
 					role="row">
 					<div role="cell" class="p-2">{submission.time}</div>
 					<div role="cell" class="p-2">
@@ -60,8 +66,32 @@
 					<div role="cell" class="p-2">
 						<JudgementType judgement_type={submission.judgement_type} />{submission.judgement}
 					</div>
+					{#if data.hasReactions}
+						<div role="cell" class="p-2">
+							{#if submission.reaction && submission.reaction.length > 0}
+								<button
+									onclick={() =>
+										modal?.openReaction(
+											submission.reaction,
+											submission.team?.display_name || submission.team?.name + ' reaction video'
+										)}
+									class="
+									text-blue-600
+									dark:text-blue-400
+									hover:bg-hover
+									p-1 rounded
+									cursor-pointer">
+									Video
+								</button>
+							{:else}
+								-
+							{/if}
+						</div>
+					{/if}
 				</div>
 			{/each}
 		</div>
 	{/if}
 </div>
+
+<ReactionModal bind:this={modal} />

--- a/src/routes/team/[id]/+page.server.ts
+++ b/src/routes/team/[id]/+page.server.ts
@@ -10,6 +10,7 @@ export const load = async ({ params, depends }) => {
 	if (!cc) throw error(404);
 
 	await Promise.all([
+		cc.loadAccess(),
 		cc.loadGroups(),
 		cc.loadOrganizations(),
 		cc.loadTeams(),
@@ -69,11 +70,13 @@ export const load = async ({ params, depends }) => {
 			if (j.score != undefined) judge += j.score + '';
 		}
 		return {
+			id: s.id,
 			time: timeToMin(s.contest_time),
 			problem: util.findById(problems, s.problem_id),
 			language: util.findById(languages, s.language_id)?.name,
 			judgement: judge,
-			judgement_type: jt
+			judgement_type: jt,
+			reaction: s.reaction
 		};
 	});
 
@@ -92,6 +95,7 @@ export const load = async ({ params, depends }) => {
 		coaches: coaches,
 		contestants: contestants,
 		submissions: submissionData,
-		country: country
+		country: country,
+		hasReactions: util.hasEndpointProperty(cc.getAccess(), 'submissions', 'reaction')
 	};
 };

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -4,9 +4,12 @@
 	import Person from '$lib/ui/Person.svelte';
 	import Photo from '$lib/ui/Photo.svelte';
 	import Problem from '$lib/ui/Problem.svelte';
+	import ReactionModal from '$lib/ui/ReactionModal.svelte';
 	import { onMount } from 'svelte';
 
 	let { data } = $props();
+
+	let modal = $state<ReactionModal>();
 
 	onMount(() => {
 		const interval = setInterval(() => {
@@ -67,14 +70,17 @@
 	{#if data.submissions && data.submissions.length > 0}
 		<div class="flex flex-col">
 			<div class="text-xl">Submissions</div>
-			<div class="grid grid-table" style="grid-template-columns: 1fr 1fr 1fr 1fr" role="row">
+			<div class="grid grid-table" style="grid-template-columns: 1fr 1fr 1fr 1fr 1fr" role="row">
 				<div role="cell" class="">Time</div>
 				<div role="cell" class="">Problem</div>
 				<div role="cell" class="">Language</div>
 				<div role="cell" class="">Judgement</div>
+				{#if data.hasReactions}
+					<div role="cell" class="">Reaction Video</div>
+				{/if}
 			</div>
 			{#each data.submissions as submission}
-				<div class="grid grid-table" style="grid-template-columns: 1fr 1fr 1fr 1fr" role="row">
+				<div class="grid grid-table" style="grid-template-columns: 1fr 1fr 1fr 1fr 1fr" role="row">
 					<div role="cell" class="">{submission.time}</div>
 					<div role="cell" class="">
 						<Problem problem={submission.problem} onclick={() => goto('/problem/' + submission.problem?.id)} />
@@ -83,6 +89,28 @@
 					<div role="cell" class="">
 						<JudgementType judgement_type={submission.judgement_type} />{submission.judgement}
 					</div>
+					{#if data.hasReactions}
+						<div role="cell" class="p-2">
+							{#if submission.reaction && submission?.reaction.length > 0}
+								<button
+									onclick={() =>
+										modal?.openReaction(
+											submission.reaction,
+											data.team?.display_name || data.team?.name + ' reaction video'
+										)}
+									class="
+									text-blue-600
+									dark:text-blue-400
+									hover:bg-hover
+									p-1 rounded
+									cursor-pointer">
+									Video
+								</button>
+							{:else}
+								-
+							{/if}
+						</div>
+					{/if}
 				</div>
 			{/each}
 		</div>
@@ -119,3 +147,5 @@
 		</div>
 	{/if}
 </div>
+
+<ReactionModal bind:this={modal} />


### PR DESCRIPTION
Adds a generic Modal dialog (could be used for other pop-ups) and a more specific ReactionModal that can be used to display reaction videos - either a single video (from past contests where we only recorded video) or side by side if there are two videos (for contests where we now record desktop and webcam reactions).

Adds reaction data to both the team's list of submissions and the problem page that lists submissions, then adds a new column for reaction videos to both pages (when they exist). Clicking on a reaction video opens the modal reaction dialog.

Issues:
- I don't have a good (non-complicated) way to do 'optional columns' at the moment, so the space for the reaction column is always there. If there are no reactions it's just empty space. IMHO this is fine for now and we need to work on column width/proportional columns later anyway.
- Sometimes the videos don't load. I'm pretty sure this is due to running browser/team-view/CDS on one machine and unrelated to this change. :)

Fixes #26.

Sample (people covered in black since this is random test data):
<img width="1531" height="675" alt="Screenshot 2026-02-11 at 8 58 14 PM" src="https://github.com/user-attachments/assets/3eec18f0-f6ff-49f8-8533-db3ba8842236" />