### PR TITLE
chore: use access for map info

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,5 +1,6 @@
 import { loadContest } from '$lib/state.svelte.js';
 import { error } from '@sveltejs/kit';
+import { ContestUtil } from 'contest-api';
 
 export const load = async ({ depends }) => {
 	const cc = await loadContest();
@@ -7,16 +8,19 @@ export const load = async ({ depends }) => {
 
 	depends('data:contest');
 
-	await Promise.all([cc.loadContest()]);
-
-	try {
-		await Promise.all([cc.loadMapInfo()]);
-	} catch (error) {
-		console.log(`Could not load map: ${error}`);
-	}
+	await Promise.all([cc.loadContest(), cc.loadAccess()]);
 
 	const contest = cc.getContest();
 	if (!contest) throw error(404);
+
+	const util = new ContestUtil();
+	if (util.hasEndpoint(cc.getAccess(), 'map-info')) {
+		try {
+			await Promise.all([cc.loadMapInfo()]);
+		} catch (error) {
+			console.log(`Could not load map: ${error}`);
+		}
+	}
 
 	return {
 		contest: contest,


### PR DESCRIPTION
Currently, the map-info endpoint is hit every few seconds to see if it exists. Because it fails if we're not on a CDS or the contest doesn't have a map, it keeps trying.

Now that we have /access support, we can just look to see if maps are supported before trying to hit the endpoint.

Net: one extra /access call on startup to check if /map-info exists. If CDS:
ping it once to get data. If not CDS: never attempt to load it.