### PR TITLE
chore: make hover colour lighter for light mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,5 @@
 @import 'tailwindcss';
 
 @theme {
-	--color-hover: light-dark(var(--color-gray-600), var(--color-gray-700));
+	--color-hover: light-dark(var(--color-gray-400), var(--color-gray-700));
 }


### PR DESCRIPTION
The hover color for light mode was fairly dark (because the header is still a fairly dark colour). We should make the header lighter, but this strikes a balance at makes the hover colour work better for header and regular content for now.