### PR TITLE
chore: remove sveltekit dep from scoreboard header

### DIFF
--- a/src/lib/ui/ScoreboardHeader.svelte
+++ b/src/lib/ui/ScoreboardHeader.svelte
@@ -2,17 +2,24 @@
 	import type { Problem as ProblemObj } from 'contest-api';
 	import Problem from './Problem.svelte';
 	import { getColumns } from './scoreboard-util';
-	import { goto } from '$app/navigation';
 
 	interface Props {
 		showLogo?: boolean;
 		scoreboard_type?: 'pass-fail' | 'score';
 		problems: ProblemObj[];
+		onselectproblem?: (problem: ProblemObj) => void;
 	}
 
-	let { scoreboard_type = 'pass-fail', problems, showLogo = true }: Props = $props();
+	let { scoreboard_type = 'pass-fail', problems, showLogo = true, onselectproblem }: Props = $props();
 
 	let col = $derived(getColumns(scoreboard_type, problems?.length, showLogo, 'full'));
+
+	function onSelectProblem(problem: ProblemObj): void {
+		if (!problem) {
+			return;
+		}
+		onselectproblem?.(problem);
+	}
 </script>
 
 <div role="rowgroup" class="sticky top-0 bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm font-semibold">
@@ -33,11 +40,7 @@
 		{/if}
 		{#each problems as problem}
 			<div role="cell" class="justify-self-center w-3/4">
-				<Problem
-					{problem}
-					onclick={() => {
-						goto('/problem/' + problem.id);
-					}} />
+				<Problem {problem} onclick={() => onSelectProblem(problem)} />
 			</div>
 		{/each}
 	</div>

--- a/src/routes/scoreboard/+page.svelte
+++ b/src/routes/scoreboard/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { invalidate } from '$app/navigation';
+	import { goto, invalidate } from '$app/navigation';
 	import { flip } from 'svelte/animate';
 	import ScoreboardHeader from '$lib/ui/ScoreboardHeader.svelte';
 	import ScoreboardRow from '$lib/ui/ScoreboardRow.svelte';
+	import type { Problem } from 'contest-api';
 
 	let { data } = $props();
 
@@ -19,7 +20,11 @@
 </script>
 
 <div class="w-full h-full overflow-auto text-sm p-2 bg-white dark:bg-gray-900" role="table" aria-label="scoreboard">
-	<ScoreboardHeader showLogo={data.hasLogos} scoreboard_type={data.scoreboard_type} problems={data.problems} />
+	<ScoreboardHeader
+		showLogo={data.hasLogos}
+		scoreboard_type={data.scoreboard_type}
+		problems={data.problems}
+		onselectproblem={(p: Problem) => goto('/problem/' + p.id)} />
 
 	<div role="rowgroup">
 		{#each data.scoreboard.rows as row, i (row.team_id)}


### PR DESCRIPTION
As part of #110 we need a clean set of contest ui components - no sveltekit dependency or team-view behaviours: the scoreboard header shouldn't have a hard-coded action that opens the problems page.

This just adds a level of indirection where a client can register with the scoreboard header for problem selection and do whatever action it wants.

Part of #110.