### PR TITLE
feat: use sessions to count users

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,7 +3,9 @@
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			sessionCount: number;
+		}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,29 @@
+import { sessionStore } from '$lib/session-store';
+import type { Handle } from '@sveltejs/kit';
+import { randomBytes } from 'crypto';
+
+function generateSessionId(): string {
+	return randomBytes(32).toString('hex');
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+	let sessionId = event.cookies.get('session_id');
+
+	if (!sessionId || !sessionStore.hasSession(sessionId)) {
+		sessionId = generateSessionId();
+		event.cookies.set('session_id', sessionId, {
+			path: '/',
+			httpOnly: true,
+			sameSite: 'lax',
+			secure: process.env.NODE_ENV === 'production',
+			maxAge: 60 * 60 * 12 // 12 hours
+		});
+		console.log('Users: ' + sessionStore.getSessionCount());
+	}
+
+	sessionStore.addSession(sessionId);
+
+	event.locals.sessionCount = sessionStore.getSessionCount();
+
+	return resolve(event);
+};

--- a/src/lib/session-store.ts
+++ b/src/lib/session-store.ts
@@ -1,0 +1,53 @@
+/**
+ * Simple in-memory session store to track unique users
+ */
+class SessionStore {
+	private sessions: Set<string> = new Set();
+	private sessionTimestamps: Map<string, number> = new Map();
+	private readonly SESSION_TIMEOUT = 60 * 60 * 1000 * 12; // 12 hours
+
+	/**
+	 * Add or update a session
+	 */
+	addSession(sessionId: string): void {
+		this.sessions.add(sessionId);
+		this.sessionTimestamps.set(sessionId, Date.now());
+		this.cleanupExpiredSessions();
+	}
+
+	/**
+	 * Get the count of active sessions
+	 */
+	getSessionCount(): number {
+		this.cleanupExpiredSessions();
+		return this.sessions.size + 1;
+	}
+
+	/**
+	 * Remove expired sessions (inactive for more than SESSION_TIMEOUT)
+	 */
+	private cleanupExpiredSessions(): void {
+		const now = Date.now();
+		const expiredSessions: string[] = [];
+
+		for (const [sessionId, timestamp] of this.sessionTimestamps.entries()) {
+			if (now - timestamp > this.SESSION_TIMEOUT) {
+				expiredSessions.push(sessionId);
+			}
+		}
+
+		for (const sessionId of expiredSessions) {
+			this.sessions.delete(sessionId);
+			this.sessionTimestamps.delete(sessionId);
+		}
+	}
+
+	/**
+	 * Check if a session exists
+	 */
+	hasSession(sessionId: string): boolean {
+		return this.sessions.has(sessionId);
+	}
+}
+
+export const sessionStore = new SessionStore();


### PR DESCRIPTION
Adds a simple session store using cookies to track users, and outputs the count to the console every time a new user connects. Count easily count # of pages visited too, but gives a basic idea of use for now.

Fixes #88.