### PR TITLE
chore: fix container build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,21 @@ RUN npm install -g pnpm && apk add --no-cache tini git
 WORKDIR /app
 
 # Copy package files and workspace configuration
-COPY package*.json pnpm-workspace.yaml ./
-COPY packages ./packages
+COPY package*.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY packages/contest-api/package.json ./packages/contest-api/
+COPY packages/contest-ui/package.json ./packages/contest-ui/
 
-# Install dependencies and tini
-RUN pnpm install
+# Install dependencies (including devDependencies needed for build)
+RUN pnpm install --frozen-lockfile
 
 # Copy source code
 COPY . .
 
-# Set build-time environment variables
-ENV NODE_ENV=production
-
-# Build the application
+# Build the application (before setting NODE_ENV=production)
 RUN pnpm run build
+
+# Set runtime environment variables
+ENV NODE_ENV=production
 
 # Create a non-root user
 RUN addgroup -g 1001 -S nodejs

--- a/packages/contest-api/package.json
+++ b/packages/contest-api/package.json
@@ -19,6 +19,7 @@
 		}
 	},
 	"scripts": {
+		"build": "echo 'No build needed for contest-api yet - using TypeScript source directly'",
 		"test": "vitest"
 	},
 	"dependencies": {


### PR DESCRIPTION
Odd that the build didn't fail immediately but it looks like things were cached. This changes a few things to fix it and improve the process:
- Copy all three package.json files and the lock file in.
- pnpm install with a frozen lockfile to ensure dependencies are exactly what's in git / repeatable build.
- Delay setting NODE_ENV=production until after the build so that dev dependencies (like svelte-package) are used during the build.
- Add contest-api build (that does nothing for now) to be consistent.