### PR TITLE
feat: table component

### DIFF
--- a/src/lib/submissionData.ts
+++ b/src/lib/submissionData.ts
@@ -1,0 +1,11 @@
+import type { FileReference, JudgementType, Language, Problem, RelTime, Team } from '@icpctools/contest-api';
+
+export interface SubmissionData {
+	id: string;
+	time: RelTime;
+	problem: Problem;
+	language: Language;
+	team: Team;
+	judgementType: JudgementType | undefined;
+	reaction: FileReference[];
+}

--- a/src/lib/ui/table/JudgementTypeColumn.svelte
+++ b/src/lib/ui/table/JudgementTypeColumn.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import type { JudgementType } from '@icpctools/contest-api';
+	import { JudgementTypeUI } from '@icpctools/contest-ui';
+
+	interface Props {
+		object?: JudgementType;
+	}
+	let { object }: Props = $props();
+</script>
+
+<div class="max-w-full">
+	{#if object}
+		<JudgementTypeUI judgementType={object} />
+	{/if}
+</div>

--- a/src/lib/ui/table/ProblemColumn.svelte
+++ b/src/lib/ui/table/ProblemColumn.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { Problem } from '@icpctools/contest-api';
+	import { ProblemUI } from '@icpctools/contest-ui';
+
+	interface Props {
+		object: Problem;
+		onclick?: () => void;
+	}
+	let { object, onclick }: Props = $props();
+</script>
+
+<div class="w-12">
+	{#if object}
+		<ProblemUI problem={object} {onclick} />
+	{/if}
+</div>

--- a/src/lib/ui/table/ReactionColumn.svelte
+++ b/src/lib/ui/table/ReactionColumn.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import type { FileReference } from '@icpctools/contest-api';
+
+	interface Props {
+		object?: FileReference[];
+		onclick?: () => void;
+	}
+	let { object, onclick }: Props = $props();
+</script>
+
+<div class="w-full">
+	{#if object && object?.length > 0}
+		<button
+			{onclick}
+			class="
+			text-blue-600
+			dark:text-blue-400
+			hover:bg-hover
+			p-0.5 rounded
+			cursor-pointer">
+			Video
+		</button>
+	{:else}
+		-
+	{/if}
+</div>

--- a/src/lib/ui/table/SimpleColumn.svelte
+++ b/src/lib/ui/table/SimpleColumn.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	interface Props {
+		object: string;
+	}
+	let { object }: Props = $props();
+</script>
+
+<div class="text-black dark:text-white max-w-full text-wrap">
+	{object}
+</div>

--- a/src/lib/ui/table/Table.svelte
+++ b/src/lib/ui/table/Table.svelte
@@ -1,0 +1,164 @@
+<script lang="ts" generics="T extends { id?: string }">
+	import { onMount } from 'svelte';
+	import { flip } from 'svelte/animate';
+	import type { Column } from './table';
+
+	interface Props {
+		kind: string;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		columns: Column<T, any>[];
+		data: T[];
+		defaultSortColumn: string | undefined;
+	}
+	let { kind, columns, data, defaultSortColumn = undefined }: Props = $props();
+
+	let sortCol = $state<Column<T>>();
+	let sortAscending = $state<boolean>();
+
+	let data2 = $derived.by(() => {
+		if (!data || !sortCol) {
+			return data;
+		} else {
+			return sortImpl();
+		}
+	});
+
+	function sort(column: Column<T>): void {
+		if (!column) {
+			return;
+		}
+
+		let comparator = column.info.comparator;
+		if (!comparator) {
+			// column is not sortable
+			return;
+		}
+
+		if (sortCol === column) {
+			sortAscending = !sortAscending;
+		} else {
+			sortCol = column;
+			sortAscending = column.info.initialOrder ? column.info.initialOrder !== 'descending' : true;
+		}
+		sortImpl();
+	}
+
+	function sortImpl(): T[] {
+		// confirm we're sorting
+		if (!sortCol) {
+			return data;
+		}
+
+		let comparator = sortCol.info.comparator;
+		if (!comparator) {
+			// column is not sortable
+			return data;
+		}
+
+		if (!sortAscending) {
+			// we're already sorted, switch to reverse order
+			let comparatorTemp = comparator;
+			comparator = (a, b): number => -comparatorTemp(a, b);
+		}
+
+		return data.toSorted(comparator);
+	}
+
+	onMount(async () => {
+		const column: Column<T> | undefined = columns.find((column) => column.title === defaultSortColumn);
+		if (column?.info.comparator) {
+			sortCol = column;
+			sortAscending = column.info.initialOrder ? column.info.initialOrder !== 'descending' : true;
+		}
+	});
+
+	let gridTemplateColumns = $derived.by(() => {
+		let columnWidths: string[] = ['5px'];
+
+		columns.map((c) => c.info.width ?? '1fr').forEach((w) => columnWidths.push(w));
+
+		columnWidths.push('5px');
+
+		return columnWidths.join(' ');
+	});
+</script>
+
+<div
+	style="--table-grid-table-columns: {gridTemplateColumns}"
+	class="w-full"
+	class:hidden={data2.length === 0}
+	role="table"
+	aria-label={kind}>
+	<!-- Table header -->
+	<div role="rowgroup" class="relative">
+		<div class="grid grid-table gap-x-0.5 h-7 sticky top-0 text-gray-600 dark:text-gray-300 uppercase z-2" role="row">
+			<div class="whitespace-nowrap justify-self-start" role="columnheader"></div>
+
+			{#each columns as column, index (index)}
+				<!-- svelte-ignore a11y_click_events_have_key_events -->
+				<!-- svelte-ignore a11y_interactive_supports_focus -->
+				<div
+					class="max-w-full overflow-hidden flex flex-row text-sm font-semibold items-center whitespace-nowrap {column
+						.info.align === 'right'
+						? 'justify-self-end'
+						: column.info.align === 'center'
+							? 'justify-self-center'
+							: 'justify-self-start'} self-center select-none"
+					class:cursor-pointer={column.info.comparator}
+					class:hover:text-black={sortCol !== column}
+					class:hover:dark:text-white={sortCol !== column}
+					onclick={sort.bind(undefined, column)}
+					role="columnheader">
+					<div class="overflow-hidden text-ellipsis">
+						{column.title}
+					</div>
+					{#if column.info.comparator}<i
+							class="fas pl-0.5"
+							class:fa-sort={sortCol !== column}
+							class:fa-sort-up={sortCol === column && sortAscending}
+							class:fa-sort-down={sortCol === column && !sortAscending}
+							class:text-gray-500={sortCol !== column}
+							aria-hidden="true"></i
+						>{/if}
+				</div>
+			{/each}
+		</div>
+	</div>
+	<!-- Table body -->
+	<div role="rowgroup">
+		{#each data2 as object (object)}
+			<div
+				class="min-h-10 h-fit rounded-lg even:bg-white dark:even:bg-gray-900/50 odd:bg-gray-100 dark:odd:bg-gray-800/50"
+				animate:flip={{ duration: 500 }}>
+				<div class="grid grid-table gap-x-0.5 min-h-10 hover:bg-gray-800 rounded-lg" role="row">
+					<div class="whitespace-nowrap place-self-center" role="cell"></div>
+
+					{#each columns as column, index (index)}
+						<div
+							class="whitespace-nowrap {column.info.align === 'right'
+								? 'justify-self-end'
+								: column.info.align === 'center'
+									? 'justify-self-center'
+									: 'justify-self-start'} self-center {column.info.overflow === true
+								? ''
+								: 'overflow-hidden'} max-w-full py-1.5"
+							role="cell">
+							{#if column.info.renderer}
+								<column.info.renderer
+									object={column.info.renderMapping ? column.info.renderMapping(object) : object}
+									onclick={column.info.onclick ? () => column.info.onclick?.(object) : undefined} />
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/each}
+	</div>
+</div>
+
+<style>
+	.grid-table {
+		display: grid;
+		grid-template-columns: var(--table-grid-table-columns);
+	}
+</style>

--- a/src/lib/ui/table/TeamColumn.svelte
+++ b/src/lib/ui/table/TeamColumn.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { Team } from '@icpctools/contest-api';
+
+	interface Props {
+		object: Team;
+		onclick?: () => void;
+	}
+	let { object, onclick }: Props = $props();
+</script>
+
+<div class="w-full">
+	{#if object}
+		<button
+			{onclick}
+			class="
+			text-blue-600
+			dark:text-blue-400
+			hover:bg-hover
+			p-0.5 rounded
+			cursor-pointer">
+			{object?.label}: {object?.display_name || object?.name}
+		</button>
+	{/if}
+</div>

--- a/src/lib/ui/table/table.ts
+++ b/src/lib/ui/table/table.ts
@@ -1,0 +1,80 @@
+import type { Component } from 'svelte';
+
+/**
+ * Options to be used when creating a Column.
+ */
+export interface ColumnInformation<Type, RenderType = Type> {
+	/**
+	 * Column alignment, one of 'left', 'center', or 'right'.
+	 *
+	 * Defaults to 'left' alignment.
+	 */
+	readonly align?: 'left' | 'center' | 'right';
+
+	/**
+	 * Column width, typically in pixels or fractional units (fr).
+	 *
+	 * Defaults to '1fr'.
+	 */
+	readonly width?: string;
+
+	/**
+	 * Map the source object to another type for rendering. Allows
+	 * easier reuse and sharing of renderers by converting to simple
+	 * types (e.g. rendering 'string' instead of 'type.name') or
+	 * converting to a different type.
+	 */
+	readonly renderMapping?: (object: Type) => RenderType;
+
+	/**
+	 * Svelte component, renderer for each cell in the column.
+	 * The component must have a property 'object' that has the
+	 * same type as the Column.
+	 */
+	readonly renderer?: Component<{ object: RenderType; onclick?: () => void }>;
+
+	/**
+	 * Set a comparator used to sort the data by the values in this column.
+	 */
+	readonly comparator?: (object1: Type, object2: Type) => number;
+
+	/**
+	 * The 'natural' or initial sort direction. Most columns are
+	 * naturally sorted in ascending order and do not need to
+	 * specify this value - e.g. names are sorted alphabetically.
+	 *
+	 * Columns that are naturally sorted in descending order -
+	 * e.g. file sizes or 'number of children' by biggest first -
+	 * can set this value to change the initial sort direction.
+	 *
+	 * Defaults to 'ascending'.
+	 */
+	readonly initialOrder?: 'ascending' | 'descending';
+
+	/**
+	 * By default, columns are limited to rendering within their
+	 * own cell to stop long or extraneous content (e.g. long
+	 * user-provided names) from interfering with other columns.
+	 * More advanced column renderers that need to render outside
+	 * of their cells (e.g. with popup menus or tooltips) can use
+	 * this property to allow this behaviour.
+	 *
+	 * Defaults to 'false'.
+	 */
+	readonly overflow?: boolean;
+
+	/**
+	 * Action to execute if you click on the column.
+	 */
+	readonly onclick?: (object: Type) => void;
+}
+
+/**
+ * A table Column.
+ */
+export class Column<Type, RenderType = Type> {
+	constructor(
+		readonly title: string,
+		readonly info: ColumnInformation<Type, RenderType>
+	) {}
+}

--- a/src/routes/problem/[id]/+page.server.ts
+++ b/src/routes/problem/[id]/+page.server.ts
@@ -1,7 +1,8 @@
 import { error } from '@sveltejs/kit';
 import { loadContest } from '$lib/state.svelte.js';
-import { timeToMin, ContestUtil } from '@icpctools/contest-api';
+import { ContestUtil } from '@icpctools/contest-api';
 import type { Judgement, JudgementType } from '@icpctools/contest-api';
+import type { SubmissionData } from '../../../lib/submissionData.js';
 
 export const load = async ({ params, depends }) => {
 	depends('data:problem');
@@ -53,13 +54,14 @@ export const load = async ({ params, depends }) => {
 		}
 		return {
 			id: s.id,
-			time: timeToMin(s.contest_time),
+			time: s.contest_time,
 			team: util.findById(teams, s.team_id),
-			language: util.findById(languages, s.language_id)?.name,
+			language: util.findById(languages, s.language_id),
 			judgement: judge,
 			judgementType: jt,
-			reaction: s.reaction
-		};
+			reaction: s.reaction,
+			problem: problem
+		} as SubmissionData;
 	});
 
 	return {

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
-	import { invalidate } from '$app/navigation';
-	import { JudgementTypeUI, ProblemUI } from '@icpctools/contest-ui';
+	import { goto, invalidate } from '$app/navigation';
+	import { ProblemUI } from '@icpctools/contest-ui';
 	import { onMount } from 'svelte';
 	import ReactionModal from '$lib/ui/ReactionModal.svelte';
+	import { Column } from '$lib/ui/table/table.js';
+	import type { SubmissionData } from '../../../lib/submissionData.js';
+	import { parseRelTime, timeToMin, type FileReference, type JudgementType, type Team } from '@icpctools/contest-api';
+	import SimpleColumn from '$lib/ui/table/SimpleColumn.svelte';
+	import JudgementTypeColumn from '$lib/ui/table/JudgementTypeColumn.svelte';
+	import ReactionColumn from '$lib/ui/table/ReactionColumn.svelte';
+	import Table from '$lib/ui/table/Table.svelte';
+	import TeamColumn from '$lib/ui/table/TeamColumn.svelte';
 
 	let { data } = $props();
 
@@ -17,6 +25,47 @@
 			clearInterval(interval);
 		};
 	});
+
+	let timeColumn = new Column<SubmissionData, string>('Time', {
+		renderMapping: (object: SubmissionData) => timeToMin(object.time),
+		renderer: SimpleColumn,
+		comparator: (a, b): number => (parseRelTime(a.time) ?? 0) - (parseRelTime(b.time) ?? 0)
+	});
+
+	let teamColumn = new Column<SubmissionData, Team>('Team', {
+		width: '3fr',
+		renderMapping: (object: SubmissionData) => object.team,
+		renderer: TeamColumn,
+		onclick: (object: SubmissionData) => goto(`/team/${object.team?.id}`),
+		comparator: (a, b): number =>
+			(a.team.display_name ?? a.team.name ?? 'a').localeCompare(b.team.display_name ?? b.team.name ?? 'a')
+	});
+
+	let languageColumn = new Column<SubmissionData, string>('Language', {
+		renderMapping: (object: SubmissionData) => object.language?.name,
+		renderer: SimpleColumn,
+		comparator: (a, b): number => a.language.name.localeCompare(b.language.name)
+	});
+
+	let judgementTypeColumn = new Column<SubmissionData, JudgementType | undefined>('Judgement', {
+		renderMapping: (object: SubmissionData) => object.judgementType,
+		renderer: JudgementTypeColumn,
+		comparator: (a, b): number => (a.judgementType?.name ?? 'a').localeCompare(b.judgementType?.name ?? 'a')
+	});
+
+	let reactionColumn = new Column<SubmissionData, FileReference[]>('Reaction Video', {
+		renderMapping: (object: SubmissionData) => object.reaction,
+		renderer: ReactionColumn,
+		onclick: (object: SubmissionData) =>
+			modal?.openReaction(object.reaction, object.team?.display_name || object.team?.name + ' reaction video')
+	});
+
+	const columns = [timeColumn, teamColumn, languageColumn, judgementTypeColumn];
+
+	// svelte-ignore state_referenced_locally
+	if (data.hasReactions) {
+		columns.push(reactionColumn);
+	}
 </script>
 
 <div class="flex flex-col p-2 gap-1 h-full overflow-auto bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
@@ -39,56 +88,7 @@
 		<div class="flex flex-col">
 			<div class="text-xl">Submissions ({data.submissions.length})</div>
 
-			<div
-				class="grid grid-table bg-gray-100 dark:bg-gray-800"
-				style="grid-template-columns: 1fr 1fr 1fr 1fr 1fr"
-				role="row">
-				<div role="cell" class="p-2 font-semibold">Time</div>
-				<div role="cell" class="p-2 font-semibold">Team</div>
-				<div role="cell" class="p-2 font-semibold">Language</div>
-				<div role="cell" class="p-2 font-semibold">Judgement</div>
-				{#if data.hasReactions}
-					<div role="cell" class="p-2 font-semibold">Reaction Video</div>
-				{/if}
-			</div>
-			{#each data.submissions as submission (submission.id)}
-				<div
-					class="grid grid-table even:bg-white dark:even:bg-gray-900 odd:bg-gray-50 dark:odd:bg-gray-800"
-					style="grid-template-columns: 1fr 1fr 1fr 1fr 1fr"
-					role="row">
-					<div role="cell" class="p-2">{submission.time}</div>
-					<div role="cell" class="p-2">
-						<a href="/team/{submission.team?.id}" class="text-blue-600 dark:text-blue-400 hover:bg-hover p-1 rounded"
-							>{submission.team?.label}: {submission.team?.display_name || submission.team?.name}</a>
-					</div>
-					<div role="cell" class="p-2">{submission.language}</div>
-					<div role="cell" class="p-2">
-						<JudgementTypeUI judgementType={submission.judgementType} />{submission.judgement}
-					</div>
-					{#if data.hasReactions}
-						<div role="cell" class="p-2">
-							{#if submission.reaction && submission.reaction.length > 0}
-								<button
-									onclick={() =>
-										modal?.openReaction(
-											submission.reaction,
-											submission.team?.display_name || submission.team?.name + ' reaction video'
-										)}
-									class="
-									text-blue-600
-									dark:text-blue-400
-									hover:bg-hover
-									p-1 rounded
-									cursor-pointer">
-									Video
-								</button>
-							{:else}
-								-
-							{/if}
-						</div>
-					{/if}
-				</div>
-			{/each}
+			<Table kind="submissions" data={data.submissions} {columns} defaultSortColumn="Time"></Table>
 		</div>
 	{/if}
 </div>

--- a/src/routes/team/[id]/+page.server.ts
+++ b/src/routes/team/[id]/+page.server.ts
@@ -1,8 +1,8 @@
 import { error } from '@sveltejs/kit';
 import { ContestUtil } from '@icpctools/contest-api';
 import { loadContest } from '$lib/state.svelte.js';
-import { timeToMin } from '@icpctools/contest-api';
 import type { Judgement, JudgementType } from '@icpctools/contest-api';
+import type { SubmissionData } from '$lib/submissionData';
 
 export const load = async ({ params, depends }) => {
 	depends('data:team');
@@ -71,13 +71,14 @@ export const load = async ({ params, depends }) => {
 		}
 		return {
 			id: s.id,
-			time: timeToMin(s.contest_time),
+			time: s.contest_time,
+			team: team,
 			problem: util.findById(problems, s.problem_id),
-			language: util.findById(languages, s.language_id)?.name,
+			language: util.findById(languages, s.language_id),
 			judgement: judge,
 			judgementType: jt,
 			reaction: s.reaction
-		};
+		} as SubmissionData;
 	});
 
 	let country;

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -1,12 +1,60 @@
 <script lang="ts">
 	import { goto, invalidate } from '$app/navigation';
-	import { JudgementTypeUI, PersonUI, Photo, ProblemUI } from '@icpctools/contest-ui';
-	import ReactionModal from '$lib/ui/ReactionModal.svelte';
+	import type { Problem, FileReference, JudgementType } from '@icpctools/contest-api';
+	import { PersonUI, Photo } from '@icpctools/contest-ui';
 	import { onMount } from 'svelte';
+	import { Column } from '$lib/ui/table/table';
+	import SimpleColumn from '$lib/ui/table/SimpleColumn.svelte';
+	import Table from '$lib/ui/table/Table.svelte';
+	import { timeToMin, parseRelTime } from '@icpctools/contest-api';
+	import JudgementTypeColumn from '$lib/ui/table/JudgementTypeColumn.svelte';
+	import ProblemColumn from '$lib/ui/table/ProblemColumn.svelte';
+	import ReactionColumn from '$lib/ui/table/ReactionColumn.svelte';
+	import ReactionModal from '$lib/ui/ReactionModal.svelte';
+	import type { SubmissionData } from '$lib/submissionData.js';
 
 	let { data } = $props();
 
 	let modal = $state<ReactionModal>();
+
+	let timeColumn = new Column<SubmissionData, string>('Time', {
+		renderMapping: (object: SubmissionData) => timeToMin(object.time),
+		renderer: SimpleColumn,
+		comparator: (a, b): number => (parseRelTime(a.time) ?? 0) - (parseRelTime(b.time) ?? 0)
+	});
+
+	let problemColumn = new Column<SubmissionData, Problem>('Problem', {
+		renderMapping: (object: SubmissionData) => object.problem,
+		renderer: ProblemColumn,
+		onclick: (object: SubmissionData) => goto(`/problem/${object.problem.id}`),
+		comparator: (a, b): number => a.problem.ordinal - b.problem.ordinal
+	});
+
+	let languageColumn = new Column<SubmissionData, string>('Language', {
+		renderMapping: (object: SubmissionData) => object.language.name,
+		renderer: SimpleColumn,
+		comparator: (a, b): number => a.language.name.localeCompare(b.language.name)
+	});
+
+	let judgementTypeColumn = new Column<SubmissionData, JudgementType | undefined>('Judgement', {
+		renderMapping: (object: SubmissionData) => object.judgementType,
+		renderer: JudgementTypeColumn,
+		comparator: (a, b): number => (a.judgementType?.name ?? 'a').localeCompare(b.judgementType?.name ?? 'a')
+	});
+
+	let reactionColumn = new Column<SubmissionData, FileReference[]>('Reaction Video', {
+		renderMapping: (object: SubmissionData) => object.reaction,
+		renderer: ReactionColumn,
+		onclick: (object: SubmissionData) =>
+			modal?.openReaction(object.reaction, data.team?.display_name || data.team?.name + ' reaction video')
+	});
+
+	const columns = [timeColumn, problemColumn, languageColumn, judgementTypeColumn];
+
+	// svelte-ignore state_referenced_locally
+	if (data.hasReactions) {
+		columns.push(reactionColumn);
+	}
 
 	onMount(() => {
 		const interval = setInterval(() => {
@@ -67,49 +115,8 @@
 	{#if data.submissions && data.submissions.length > 0}
 		<div class="flex flex-col">
 			<div class="text-xl">Submissions</div>
-			<div class="grid grid-table" style="grid-template-columns: 1fr 1fr 1fr 1fr 1fr" role="row">
-				<div role="cell" class="">Time</div>
-				<div role="cell" class="">Problem</div>
-				<div role="cell" class="">Language</div>
-				<div role="cell" class="">Judgement</div>
-				{#if data.hasReactions}
-					<div role="cell" class="">Reaction Video</div>
-				{/if}
-			</div>
-			{#each data.submissions as submission (submission.id)}
-				<div class="grid grid-table" style="grid-template-columns: 1fr 1fr 1fr 1fr 1fr" role="row">
-					<div role="cell" class="">{submission.time}</div>
-					<div role="cell" class="">
-						<ProblemUI problem={submission.problem} onclick={() => goto('/problem/' + submission.problem?.id)} />
-					</div>
-					<div role="cell" class="">{submission.language}</div>
-					<div role="cell" class="">
-						<JudgementTypeUI judgementType={submission.judgementType} />{submission.judgement}
-					</div>
-					{#if data.hasReactions}
-						<div role="cell" class="p-2">
-							{#if submission.reaction && submission?.reaction.length > 0}
-								<button
-									onclick={() =>
-										modal?.openReaction(
-											submission.reaction,
-											data.team?.display_name || data.team?.name + ' reaction video'
-										)}
-									class="
-									text-blue-600
-									dark:text-blue-400
-									hover:bg-hover
-									p-1 rounded
-									cursor-pointer">
-									Video
-								</button>
-							{:else}
-								-
-							{/if}
-						</div>
-					{/if}
-				</div>
-			{/each}
+
+			<Table kind="submissions" data={data.submissions} {columns} defaultSortColumn="Time"></Table>
 		</div>
 	{/if}
 


### PR DESCRIPTION
A long time ago I created Tables for another project, and the core of that still works great for this case.

Instead of manually iterating and styling, the Table component controls all the standard styling and controls. Columns are added programmatically, with column renderers that decide how to display a single data object (like problems or judgements) at a time.

The benefit of this approach is that changing the columns or layout of a table is easy, and we get some nice features like sorting and animation.

It was hard to break this up, so this commit adds the reusable Table component, some column renderers, and switches both the problem and team pages to use them.

Fixes #122.

Before:
<img width="848" height="226" alt="Screenshot 2026-02-18 at 4 53 50 PM" src="https://github.com/user-attachments/assets/cf2ee64b-32f6-48d5-ba56-b108545990f7" />

<img width="848" height="226" alt="Screenshot 2026-02-18 at 4 53 31 PM" src="https://github.com/user-attachments/assets/2a537e06-fbcb-44f3-9b94-214d57f69063" />

After:
<img width="848" height="226" alt="Screenshot 2026-02-18 at 4 52 25 PM" src="https://github.com/user-attachments/assets/1b1d984f-6f00-4f31-b836-819deb25ced3" />

<img width="848" height="226" alt="Screenshot 2026-02-18 at 4 52 51 PM" src="https://github.com/user-attachments/assets/50a3c53b-3078-406c-9ac7-cdef8983a838" />