### PR TITLE
chore: table property simplification

### DIFF
--- a/src/lib/ui/table/JudgementTypeColumn.svelte
+++ b/src/lib/ui/table/JudgementTypeColumn.svelte
@@ -3,13 +3,13 @@
 	import { JudgementTypeUI } from '@icpctools/contest-ui';
 
 	interface Props {
-		object?: JudgementType;
+		judgementType?: JudgementType;
 	}
-	let { object }: Props = $props();
+	let { judgementType }: Props = $props();
 </script>
 
 <div class="max-w-full">
-	{#if object}
-		<JudgementTypeUI judgementType={object} />
+	{#if judgementType}
+		<JudgementTypeUI {judgementType} />
 	{/if}
 </div>

--- a/src/lib/ui/table/ProblemColumn.svelte
+++ b/src/lib/ui/table/ProblemColumn.svelte
@@ -3,14 +3,14 @@
 	import { ProblemUI } from '@icpctools/contest-ui';
 
 	interface Props {
-		object: Problem;
+		problem: Problem;
 		onclick?: () => void;
 	}
-	let { object, onclick }: Props = $props();
+	let { problem, onclick }: Props = $props();
 </script>
 
 <div class="w-12">
-	{#if object}
-		<ProblemUI problem={object} {onclick} />
+	{#if problem}
+		<ProblemUI {problem} {onclick} />
 	{/if}
 </div>

--- a/src/lib/ui/table/ReactionColumn.svelte
+++ b/src/lib/ui/table/ReactionColumn.svelte
@@ -2,14 +2,14 @@
 	import type { FileReference } from '@icpctools/contest-api';
 
 	interface Props {
-		object?: FileReference[];
+		reaction?: FileReference[];
 		onclick?: () => void;
 	}
-	let { object, onclick }: Props = $props();
+	let { reaction, onclick }: Props = $props();
 </script>
 
 <div class="w-full">
-	{#if object && object?.length > 0}
+	{#if reaction && reaction?.length > 0}
 		<button
 			{onclick}
 			class="

--- a/src/lib/ui/table/Table.svelte
+++ b/src/lib/ui/table/Table.svelte
@@ -5,8 +5,7 @@
 
 	interface Props {
 		kind: string;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		columns: Column<T, any>[];
+		columns: Column<T>[];
 		data: T[];
 		defaultSortColumn: string | undefined;
 	}
@@ -144,9 +143,7 @@
 								: 'overflow-hidden'} max-w-full py-1.5"
 							role="cell">
 							{#if column.info.renderer}
-								<column.info.renderer
-									object={column.info.renderMapping ? column.info.renderMapping(object) : object}
-									onclick={column.info.onclick ? () => column.info.onclick?.(object) : undefined} />
+								<column.info.renderer {...column.info.rendererProps?.(object)} />
 							{/if}
 						</div>
 					{/each}

--- a/src/lib/ui/table/TeamColumn.svelte
+++ b/src/lib/ui/table/TeamColumn.svelte
@@ -2,14 +2,14 @@
 	import type { Team } from '@icpctools/contest-api';
 
 	interface Props {
-		object: Team;
+		team: Team;
 		onclick?: () => void;
 	}
-	let { object, onclick }: Props = $props();
+	let { team, onclick }: Props = $props();
 </script>
 
 <div class="w-full">
-	{#if object}
+	{#if team}
 		<button
 			{onclick}
 			class="
@@ -18,7 +18,7 @@
 			hover:bg-hover
 			p-0.5 rounded
 			cursor-pointer">
-			{object?.label}: {object?.display_name || object?.name}
+			{team.label}: {team.display_name || team.name}
 		</button>
 	{/if}
 </div>

--- a/src/lib/ui/table/table.ts
+++ b/src/lib/ui/table/table.ts
@@ -3,7 +3,7 @@ import type { Component } from 'svelte';
 /**
  * Options to be used when creating a Column.
  */
-export interface ColumnInformation<Type, RenderType = Type> {
+export interface ColumnInformation<Type> {
 	/**
 	 * Column alignment, one of 'left', 'center', or 'right'.
 	 *
@@ -19,19 +19,17 @@ export interface ColumnInformation<Type, RenderType = Type> {
 	readonly width?: string;
 
 	/**
-	 * Map the source object to another type for rendering. Allows
-	 * easier reuse and sharing of renderers by converting to simple
-	 * types (e.g. rendering 'string' instead of 'type.name') or
-	 * converting to a different type.
+	 * Svelte component, renderer for each cell in the column.
 	 */
-	readonly renderMapping?: (object: Type) => RenderType;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	readonly renderer?: Component<any>;
 
 	/**
-	 * Svelte component, renderer for each cell in the column.
-	 * The component must have a property 'object' that has the
-	 * same type as the Column.
+	 * Properties to pass to the renderer component.
+	 * These properties will be spread onto the component, allowing you
+	 * to renderer components with any property.
 	 */
-	readonly renderer?: Component<{ object: RenderType; onclick?: () => void }>;
+	readonly rendererProps?: (object: Type) => Record<string, unknown>;
 
 	/**
 	 * Set a comparator used to sort the data by the values in this column.
@@ -62,19 +60,14 @@ export interface ColumnInformation<Type, RenderType = Type> {
 	 * Defaults to 'false'.
 	 */
 	readonly overflow?: boolean;
-
-	/**
-	 * Action to execute if you click on the column.
-	 */
-	readonly onclick?: (object: Type) => void;
 }
 
 /**
  * A table Column.
  */
-export class Column<Type, RenderType = Type> {
+export class Column<Type> {
 	constructor(
 		readonly title: string,
-		readonly info: ColumnInformation<Type, RenderType>
+		readonly info: ColumnInformation<Type>
 	) {}
 }

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -5,7 +5,7 @@
 	import ReactionModal from '$lib/ui/ReactionModal.svelte';
 	import { Column } from '$lib/ui/table/table.js';
 	import type { SubmissionData } from '../../../lib/submissionData.js';
-	import { parseRelTime, timeToMin, type FileReference, type JudgementType, type Team } from '@icpctools/contest-api';
+	import { parseRelTime, timeToMin } from '@icpctools/contest-api';
 	import SimpleColumn from '$lib/ui/table/SimpleColumn.svelte';
 	import JudgementTypeColumn from '$lib/ui/table/JudgementTypeColumn.svelte';
 	import ReactionColumn from '$lib/ui/table/ReactionColumn.svelte';
@@ -26,38 +26,39 @@
 		};
 	});
 
-	let timeColumn = new Column<SubmissionData, string>('Time', {
-		renderMapping: (object: SubmissionData) => timeToMin(object.time),
+	let timeColumn = new Column<SubmissionData>('Time', {
 		renderer: SimpleColumn,
+		rendererProps: (object: SubmissionData) => ({ object: timeToMin(object.time) }),
 		comparator: (a, b): number => (parseRelTime(a.time) ?? 0) - (parseRelTime(b.time) ?? 0)
 	});
 
-	let teamColumn = new Column<SubmissionData, Team>('Team', {
+	let teamColumn = new Column<SubmissionData>('Team', {
 		width: '3fr',
-		renderMapping: (object: SubmissionData) => object.team,
 		renderer: TeamColumn,
-		onclick: (object: SubmissionData) => goto(`/team/${object.team?.id}`),
+		rendererProps: (object: SubmissionData) => ({ team: object.team, onclick: () => goto(`/team/${object.team?.id}`) }),
 		comparator: (a, b): number =>
 			(a.team.display_name ?? a.team.name ?? 'a').localeCompare(b.team.display_name ?? b.team.name ?? 'a')
 	});
 
-	let languageColumn = new Column<SubmissionData, string>('Language', {
-		renderMapping: (object: SubmissionData) => object.language?.name,
+	let languageColumn = new Column<SubmissionData>('Language', {
 		renderer: SimpleColumn,
+		rendererProps: (object: SubmissionData) => ({ object: object.language?.name }),
 		comparator: (a, b): number => a.language.name.localeCompare(b.language.name)
 	});
 
-	let judgementTypeColumn = new Column<SubmissionData, JudgementType | undefined>('Judgement', {
-		renderMapping: (object: SubmissionData) => object.judgementType,
+	let judgementTypeColumn = new Column<SubmissionData>('Judgement', {
 		renderer: JudgementTypeColumn,
+		rendererProps: (object: SubmissionData) => ({ judgementType: object.judgementType }),
 		comparator: (a, b): number => (a.judgementType?.name ?? 'a').localeCompare(b.judgementType?.name ?? 'a')
 	});
 
-	let reactionColumn = new Column<SubmissionData, FileReference[]>('Reaction Video', {
-		renderMapping: (object: SubmissionData) => object.reaction,
+	let reactionColumn = new Column<SubmissionData>('Reaction Video', {
 		renderer: ReactionColumn,
-		onclick: (object: SubmissionData) =>
-			modal?.openReaction(object.reaction, object.team?.display_name || object.team?.name + ' reaction video')
+		rendererProps: (object: SubmissionData) => ({
+			reaction: object.reaction,
+			onclick: () =>
+				modal?.openReaction(object.reaction, object.team?.display_name || object.team?.name + ' reaction video')
+		})
 	});
 
 	const columns = [timeColumn, teamColumn, languageColumn, judgementTypeColumn];

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { goto, invalidate } from '$app/navigation';
-	import type { Problem, FileReference, JudgementType } from '@icpctools/contest-api';
 	import { PersonUI, Photo } from '@icpctools/contest-ui';
 	import { onMount } from 'svelte';
 	import { Column } from '$lib/ui/table/table';
@@ -17,36 +16,40 @@
 
 	let modal = $state<ReactionModal>();
 
-	let timeColumn = new Column<SubmissionData, string>('Time', {
-		renderMapping: (object: SubmissionData) => timeToMin(object.time),
+	let timeColumn = new Column<SubmissionData>('Time', {
 		renderer: SimpleColumn,
+		rendererProps: (object: SubmissionData) => ({ object: timeToMin(object.time) }),
 		comparator: (a, b): number => (parseRelTime(a.time) ?? 0) - (parseRelTime(b.time) ?? 0)
 	});
 
-	let problemColumn = new Column<SubmissionData, Problem>('Problem', {
-		renderMapping: (object: SubmissionData) => object.problem,
+	let problemColumn = new Column<SubmissionData>('Problem', {
 		renderer: ProblemColumn,
-		onclick: (object: SubmissionData) => goto(`/problem/${object.problem.id}`),
+		rendererProps: (object: SubmissionData) => ({
+			problem: object.problem,
+			onclick: () => goto(`/problem/${object.problem.id}`)
+		}),
 		comparator: (a, b): number => a.problem.ordinal - b.problem.ordinal
 	});
 
-	let languageColumn = new Column<SubmissionData, string>('Language', {
-		renderMapping: (object: SubmissionData) => object.language.name,
+	let languageColumn = new Column<SubmissionData>('Language', {
 		renderer: SimpleColumn,
+		rendererProps: (object: SubmissionData) => ({ object: object.language.name }),
 		comparator: (a, b): number => a.language.name.localeCompare(b.language.name)
 	});
 
-	let judgementTypeColumn = new Column<SubmissionData, JudgementType | undefined>('Judgement', {
-		renderMapping: (object: SubmissionData) => object.judgementType,
+	let judgementTypeColumn = new Column<SubmissionData>('Judgement', {
 		renderer: JudgementTypeColumn,
+		rendererProps: (object: SubmissionData) => ({ judgementType: object.judgementType }),
 		comparator: (a, b): number => (a.judgementType?.name ?? 'a').localeCompare(b.judgementType?.name ?? 'a')
 	});
 
-	let reactionColumn = new Column<SubmissionData, FileReference[]>('Reaction Video', {
-		renderMapping: (object: SubmissionData) => object.reaction,
+	let reactionColumn = new Column<SubmissionData>('Reaction Video', {
 		renderer: ReactionColumn,
-		onclick: (object: SubmissionData) =>
-			modal?.openReaction(object.reaction, data.team?.display_name || data.team?.name + ' reaction video')
+		rendererProps: (object: SubmissionData) => ({
+			reaction: object.reaction,
+			onclick: () =>
+				modal?.openReaction(object.reaction, data.team?.display_name || data.team?.name + ' reaction video')
+		})
 	});
 
 	const columns = [timeColumn, problemColumn, languageColumn, judgementTypeColumn];


### PR DESCRIPTION
Had an idea last night - instead of each table column allowing two types (input + optional renderer type) in order to allow renderMapping, and the renderer having a required 'object' property, we could simplify and just allow any properties.

The immediate benefit is a slightly simpler table and ability to use any property name in the column components. Things like onclick can be added directly without the table even knowing about it.

Long term we might be able to use components like ProblemUI directly, without the ProblemColumn.