### PR TITLE
chore: fix light mode table highlight

### DIFF
--- a/src/lib/ui/table/Table.svelte
+++ b/src/lib/ui/table/Table.svelte
@@ -129,7 +129,7 @@
 			<div
 				class="min-h-10 h-fit rounded-lg even:bg-white dark:even:bg-gray-900/50 odd:bg-gray-100 dark:odd:bg-gray-800/50"
 				animate:flip={{ duration: 500 }}>
-				<div class="grid grid-table gap-x-0.5 min-h-10 hover:bg-gray-800 rounded-lg" role="row">
+				<div class="grid grid-table gap-x-0.5 min-h-10 hover:bg-gray-300 dark:hover:bg-gray-800 rounded-lg" role="row">
 					<div class="whitespace-nowrap place-self-center" role="cell"></div>
 
 					{#each columns as column, index (index)}


### PR DESCRIPTION
I noticed today that when you're in light mode the table row hover is dark, just fixing that.