### PR TITLE
chore: source auth

### DIFF
--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -430,6 +430,10 @@ export class ContestAPI {
 		}
 	}
 
+	getAuth() {
+		return btoa(this.credentials?.user + ':' + this.credentials?.password);
+	}
+
 	watch(): void {
 		if (this.interval) {
 			return;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -25,5 +25,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	event.locals.sessionCount = sessionStore.getSessionCount();
 
-	return resolve(event);
+	const response = await resolve(event);
+	response.headers.set('Access-Control-Allow-Origin', '*');
+	return response;
 };

--- a/src/lib/source-util.ts
+++ b/src/lib/source-util.ts
@@ -1,33 +1,40 @@
 import type { FileReference } from '@icpctools/contest-api';
 
-export async function fetchAndUnzipSubmission(source: FileReference[]): Promise<Map<string, string>> {
-	const contents = new Map<string, string>();
-	const url = source[0].href;
+export async function fetchFileReference(source: FileReference, auth: string): Promise<ArrayBuffer> {
+	console.log('Fetching file reference:', source.href);
 
-	// Import JSZip dynamically
-	const JSZip = (await import('jszip')).default;
+	const startTime = performance.now();
+	const url = source.href;
 
-	console.log('Fetching submission:', url);
-
-	// Fetch the zip file
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const response = await fetch(url).catch((err: any) => {
+	const response = await fetch(url, {
+		method: 'GET',
+		headers: { Authorization: 'Basic ' + auth }
+	}).catch((err: unknown) => {
 		throw new Error(`Failed to fetch: ${err}`);
 	});
-
 	if (!response.ok) {
-		throw new Error(`Failed to fetch submission: ${response.status} ${response.statusText}`);
+		throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
 	}
 
-	// Get as ArrayBuffer instead of Blob and confirm it's not empty
 	const arrayBuffer = await response.arrayBuffer();
 	if (arrayBuffer.byteLength === 0) {
 		throw new Error('Received empty file');
 	}
+	const endTime = performance.now();
+	console.log(`Fetched ${url} in ${(endTime - startTime).toFixed(1)}ms`);
+	return arrayBuffer;
+}
 
+export async function fetchAndUnzipSubmission(source: FileReference[], auth: string): Promise<Map<string, string>> {
+	// Import JSZip dynamically
+	const JSZip = (await import('jszip')).default;
+
+	// Fetch the zip file
+	const arrayBuffer = await fetchFileReference(source[0], auth);
 	const zip = await JSZip.loadAsync(arrayBuffer);
 
 	// Extract all files
+	const contents = new Map<string, string>();
 	for (const [filename, file] of Object.entries(zip.files)) {
 		if (!file.dir) {
 			const content = await file.async('string');

--- a/src/lib/submissionData.ts
+++ b/src/lib/submissionData.ts
@@ -9,4 +9,5 @@ export interface SubmissionData {
 	judgementType: JudgementType | undefined;
 	files: FileReference[];
 	reaction: FileReference[];
+	auth: string;
 }

--- a/src/lib/ui/SourceModal.svelte
+++ b/src/lib/ui/SourceModal.svelte
@@ -10,13 +10,13 @@
 	let sourceFiles = $state<string[]>([]);
 	let sourceCode = $state<string>('');
 
-	export function openSource(files: FileReference[] | undefined, title: string) {
+	export function openSource(files: FileReference[] | undefined, title: string, auth: string) {
 		if (!files) return;
 
 		sourceFiles = [];
 		sourceCode = 'Loading...';
 
-		fetchAndUnzipSubmission(files)
+		fetchAndUnzipSubmission(files, auth)
 			.then((map) => {
 				sourceMap = map;
 				if (!sourceMap) {

--- a/src/routes/problem/[id]/+page.server.ts
+++ b/src/routes/problem/[id]/+page.server.ts
@@ -61,7 +61,8 @@ export const load = async ({ params, depends }) => {
 			judgementType: jt,
 			files: s.files,
 			reaction: s.reaction,
-			problem: problem
+			problem: problem,
+			auth: cc.getAuth()
 		} as SubmissionData;
 	});
 

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -60,7 +60,11 @@
 		rendererProps: (object: SubmissionData) => ({
 			source: object.files,
 			onclick: () =>
-				sourceModal?.openSource(object.files, object.team?.display_name || object.team?.name + ' source code')
+				sourceModal?.openSource(
+					object.files,
+					object.team?.display_name || object.team?.name + ' source code',
+					object.auth
+				)
 		})
 	});
 

--- a/src/routes/team/[id]/+page.server.ts
+++ b/src/routes/team/[id]/+page.server.ts
@@ -78,7 +78,8 @@ export const load = async ({ params, depends }) => {
 			judgement: judge,
 			judgementType: jt,
 			files: s.files,
-			reaction: s.reaction
+			reaction: s.reaction,
+			auth: cc.getAuth()
 		} as SubmissionData;
 	});
 

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -51,7 +51,11 @@
 		rendererProps: (object: SubmissionData) => ({
 			source: object.files,
 			onclick: () =>
-				sourceModal?.openSource(object.files, object.team?.display_name || object.team?.name + ' source code')
+				sourceModal?.openSource(
+					object.files,
+					object.team?.display_name || object.team?.name + ' source code',
+					object.auth
+				)
 		})
 	});
 


### PR DESCRIPTION
Transfer the source auth token to the frontend so that it can be used by the source download, which has been refactored to allow authorization to be specified using a more generic file reference download.

Fixes #127.