### PR TITLE
chore: source language

### DIFF
--- a/src/lib/source-util.ts
+++ b/src/lib/source-util.ts
@@ -1,16 +1,34 @@
 import type { FileReference } from '@icpctools/contest-api';
 
-export async function fetchFileReference(source: FileReference, auth: string): Promise<ArrayBuffer> {
-	console.log('Fetching file reference:', source.href);
+export function getFileLanguage(filename: string): string {
+	const ext = filename.slice(filename.lastIndexOf('.') + 1);
+	switch (ext) {
+		case 'ts':
+			return 'typescript';
+
+		case 'js':
+			return 'javascript';
+
+		case 'py':
+			return 'python';
+
+		// some languages match the file extention (e.g. cpp and java) so fallback to this
+		default:
+			return ext;
+	}
+}
+
+export async function fetchFileReference(fileRef: FileReference, auth: string): Promise<ArrayBuffer> {
+	console.log('Fetching file reference:', fileRef.href);
 
 	const startTime = performance.now();
-	const url = source.href;
+	const url = fileRef.href;
 
 	const response = await fetch(url, {
 		method: 'GET',
 		headers: { Authorization: 'Basic ' + auth }
 	}).catch((err: unknown) => {
-		throw new Error(`Failed to fetch: ${err}`);
+		throw err;
 	});
 	if (!response.ok) {
 		throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);

--- a/src/lib/ui/CodeEditor.svelte
+++ b/src/lib/ui/CodeEditor.svelte
@@ -9,7 +9,7 @@
 		theme?: string;
 	}
 
-	let { value = $bindable(), language = 'text', theme = 'vs-dark' }: Props = $props();
+	let { value = $bindable(), language = $bindable('text'), theme = 'vs-dark' }: Props = $props();
 
 	let editor = $state<Monaco.editor.IStandaloneCodeEditor>();
 	let monaco = $state<typeof Monaco>();
@@ -26,7 +26,7 @@
 		// monaco instance is ready, let's display some code!
 		editor = monaco.editor.create(editorContainer, {
 			value,
-			language,
+			language: language,
 			theme,
 			automaticLayout: true,
 			overviewRulerLanes: 0,
@@ -52,6 +52,12 @@
 		}
 		if (value === '') {
 			editor?.setValue(' ');
+		}
+	});
+
+	$effect(() => {
+		if (editor) {
+			monaco?.editor.setModelLanguage(editor.getModel(), language);
 		}
 	});
 

--- a/src/lib/ui/SourceModal.svelte
+++ b/src/lib/ui/SourceModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fetchAndUnzipSubmission } from '$lib/source-util';
+	import { fetchAndUnzipSubmission, getFileLanguage } from '$lib/source-util';
 	import CodeEditor from './CodeEditor.svelte';
 	import Modal from './Modal.svelte';
 	import type { FileReference } from '@icpctools/contest-api';
@@ -9,8 +9,9 @@
 	let sourceMap = $state<Map<string, string>>();
 	let sourceFiles = $state<string[]>([]);
 	let sourceCode = $state<string>('');
+	let language = $state('text');
 
-	export function openSource(files: FileReference[] | undefined, title: string, auth: string) {
+	export function openSource(files: FileReference[] | undefined, title: string, auth: string): void {
 		if (!files) return;
 
 		sourceFiles = [];
@@ -27,12 +28,16 @@
 				sourceFiles = [...sourceMap.keys()];
 				if (sourceFiles.length > 0) {
 					sourceCode = sourceMap.get(sourceFiles[0]) ?? 'Not found';
+					language = getFileLanguage(sourceFiles[0]);
 				}
 			})
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			.catch((err: any) => {
+			.catch((err: unknown) => {
 				sourceFiles = [];
-				sourceCode = 'Error: ' + err;
+				if (err instanceof TypeError) {
+					sourceCode = err.message;
+				} else {
+					sourceCode = 'Error: ' + err;
+				}
 			});
 
 		modal?.open(title);
@@ -56,7 +61,7 @@
 			{/each}
 		</div>
 		<div class="flex max-w-full w-full h-full">
-			<CodeEditor value={sourceCode}></CodeEditor>
+			<CodeEditor value={sourceCode} bind:language></CodeEditor>
 		</div>
 	</div>
 </Modal>


### PR DESCRIPTION
Sets the source language in the Monaco editor based on the file extension. Also displays any error message directly - still not always the best error message and more details are often in the console, but shorter and without extraneous text now.

Fixes #128.