### PR TITLE
chore: table column simplification

### DIFF
--- a/src/lib/ui/table/Table.svelte
+++ b/src/lib/ui/table/Table.svelte
@@ -27,7 +27,7 @@
 			return;
 		}
 
-		let comparator = column.info.comparator;
+		let comparator = column.comparator;
 		if (!comparator) {
 			// column is not sortable
 			return;
@@ -37,7 +37,7 @@
 			sortAscending = !sortAscending;
 		} else {
 			sortCol = column;
-			sortAscending = column.info.initialOrder ? column.info.initialOrder !== 'descending' : true;
+			sortAscending = column.initialOrder ? column.initialOrder !== 'descending' : true;
 		}
 		sortImpl();
 	}
@@ -48,7 +48,7 @@
 			return data;
 		}
 
-		let comparator = sortCol.info.comparator;
+		let comparator = sortCol.comparator;
 		if (!comparator) {
 			// column is not sortable
 			return data;
@@ -65,16 +65,16 @@
 
 	onMount(async () => {
 		const column: Column<T> | undefined = columns.find((column) => column.title === defaultSortColumn);
-		if (column?.info.comparator) {
+		if (column?.comparator) {
 			sortCol = column;
-			sortAscending = column.info.initialOrder ? column.info.initialOrder !== 'descending' : true;
+			sortAscending = column.initialOrder ? column.initialOrder !== 'descending' : true;
 		}
 	});
 
 	let gridTemplateColumns = $derived.by(() => {
 		let columnWidths: string[] = ['5px'];
 
-		columns.map((c) => c.info.width ?? '1fr').forEach((w) => columnWidths.push(w));
+		columns.map((c) => c.width ?? '1fr').forEach((w) => columnWidths.push(w));
 
 		columnWidths.push('5px');
 
@@ -97,13 +97,13 @@
 				<!-- svelte-ignore a11y_click_events_have_key_events -->
 				<!-- svelte-ignore a11y_interactive_supports_focus -->
 				<div
-					class="max-w-full overflow-hidden flex flex-row text-sm font-semibold items-center whitespace-nowrap {column
-						.info.align === 'right'
+					class="max-w-full overflow-hidden flex flex-row text-sm font-semibold items-center whitespace-nowrap {column.align ===
+					'right'
 						? 'justify-self-end'
-						: column.info.align === 'center'
+						: column.align === 'center'
 							? 'justify-self-center'
 							: 'justify-self-start'} self-center select-none"
-					class:cursor-pointer={column.info.comparator}
+					class:cursor-pointer={column.comparator}
 					class:hover:text-black={sortCol !== column}
 					class:hover:dark:text-white={sortCol !== column}
 					onclick={sort.bind(undefined, column)}
@@ -111,7 +111,7 @@
 					<div class="overflow-hidden text-ellipsis">
 						{column.title}
 					</div>
-					{#if column.info.comparator}<i
+					{#if column.comparator}<i
 							class="fas pl-0.5"
 							class:fa-sort={sortCol !== column}
 							class:fa-sort-up={sortCol === column && sortAscending}
@@ -134,17 +134,15 @@
 
 					{#each columns as column, index (index)}
 						<div
-							class="whitespace-nowrap {column.info.align === 'right'
+							class="whitespace-nowrap {column.align === 'right'
 								? 'justify-self-end'
-								: column.info.align === 'center'
+								: column.align === 'center'
 									? 'justify-self-center'
-									: 'justify-self-start'} self-center {column.info.overflow === true
+									: 'justify-self-start'} self-center {column.overflow === true
 								? ''
 								: 'overflow-hidden'} max-w-full py-1.5"
 							role="cell">
-							{#if column.info.renderer}
-								<column.info.renderer {...column.info.rendererProps?.(object)} />
-							{/if}
+							<column.renderer {...column.rendererProps?.(object)} />
 						</div>
 					{/each}
 				</div>

--- a/src/lib/ui/table/table.ts
+++ b/src/lib/ui/table/table.ts
@@ -1,9 +1,14 @@
 import type { Component } from 'svelte';
 
 /**
- * Options to be used when creating a Column.
+ * A table column.
  */
-export interface ColumnInformation<Type> {
+export interface Column<Type> {
+	/**
+	 * The column title.
+	 */
+	readonly title: string;
+
 	/**
 	 * Column alignment, one of 'left', 'center', or 'right'.
 	 *
@@ -22,7 +27,7 @@ export interface ColumnInformation<Type> {
 	 * Svelte component, renderer for each cell in the column.
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	readonly renderer?: Component<any>;
+	readonly renderer: Component<any>;
 
 	/**
 	 * Properties to pass to the renderer component.
@@ -60,14 +65,4 @@ export interface ColumnInformation<Type> {
 	 * Defaults to 'false'.
 	 */
 	readonly overflow?: boolean;
-}
-
-/**
- * A table Column.
- */
-export class Column<Type> {
-	constructor(
-		readonly title: string,
-		readonly info: ColumnInformation<Type>
-	) {}
 }

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -3,7 +3,7 @@
 	import { ProblemUI } from '@icpctools/contest-ui';
 	import { onMount } from 'svelte';
 	import ReactionModal from '$lib/ui/ReactionModal.svelte';
-	import { Column } from '$lib/ui/table/table.js';
+	import type { Column } from '$lib/ui/table/table.js';
 	import type { SubmissionData } from '../../../lib/submissionData.js';
 	import { parseRelTime, timeToMin } from '@icpctools/contest-api';
 	import SimpleColumn from '$lib/ui/table/SimpleColumn.svelte';
@@ -29,59 +29,65 @@
 		};
 	});
 
-	let timeColumn = new Column<SubmissionData>('Time', {
-		renderer: SimpleColumn,
-		rendererProps: (object: SubmissionData) => ({ object: timeToMin(object.time) }),
-		comparator: (a, b): number => (parseRelTime(a.time) ?? 0) - (parseRelTime(b.time) ?? 0)
-	});
-
-	let teamColumn = new Column<SubmissionData>('Team', {
-		width: '3fr',
-		renderer: TeamColumn,
-		rendererProps: (object: SubmissionData) => ({ team: object.team, onclick: () => goto(`/team/${object.team?.id}`) }),
-		comparator: (a, b): number =>
-			(a.team.display_name ?? a.team.name ?? 'a').localeCompare(b.team.display_name ?? b.team.name ?? 'a')
-	});
-
-	let languageColumn = new Column<SubmissionData>('Language', {
-		renderer: SimpleColumn,
-		rendererProps: (object: SubmissionData) => ({ object: object.language?.name }),
-		comparator: (a, b): number => a.language.name.localeCompare(b.language.name)
-	});
-
-	let judgementTypeColumn = new Column<SubmissionData>('Judgement', {
-		renderer: JudgementTypeColumn,
-		rendererProps: (object: SubmissionData) => ({ judgementType: object.judgementType }),
-		comparator: (a, b): number => (a.judgementType?.name ?? 'a').localeCompare(b.judgementType?.name ?? 'a')
-	});
-
-	let sourceColumn = new Column<SubmissionData>('Source Code', {
-		renderer: SourceColumn,
-		rendererProps: (object: SubmissionData) => ({
-			source: object.files,
-			onclick: () =>
-				sourceModal?.openSource(
-					object.files,
-					object.team?.display_name || object.team?.name + ' source code',
-					object.auth
-				)
-		})
-	});
-
-	let reactionColumn = new Column<SubmissionData>('Reaction Video', {
-		renderer: ReactionColumn,
-		rendererProps: (object: SubmissionData) => ({
-			reaction: object.reaction,
-			onclick: () =>
-				reactionModal?.openReaction(object.reaction, object.team?.display_name || object.team?.name + ' reaction video')
-		})
-	});
-
-	const columns = [timeColumn, teamColumn, languageColumn, judgementTypeColumn, sourceColumn];
+	const columns: Column<SubmissionData>[] = [
+		{
+			title: 'Time',
+			renderer: SimpleColumn,
+			rendererProps: (object: SubmissionData) => ({ object: timeToMin(object.time) }),
+			comparator: (a, b): number => (parseRelTime(a.time) ?? 0) - (parseRelTime(b.time) ?? 0)
+		},
+		{
+			title: 'Team',
+			width: '3fr',
+			renderer: TeamColumn,
+			rendererProps: (object: SubmissionData) => ({
+				team: object.team,
+				onclick: () => goto(`/team/${object.team?.id}`)
+			}),
+			comparator: (a, b): number =>
+				(a.team.display_name ?? a.team.name ?? 'a').localeCompare(b.team.display_name ?? b.team.name ?? 'a')
+		},
+		{
+			title: 'Language',
+			renderer: SimpleColumn,
+			rendererProps: (object: SubmissionData) => ({ object: object.language?.name }),
+			comparator: (a, b): number => a.language.name.localeCompare(b.language.name)
+		},
+		{
+			title: 'Judgement',
+			renderer: JudgementTypeColumn,
+			rendererProps: (object: SubmissionData) => ({ judgementType: object.judgementType }),
+			comparator: (a, b): number => (a.judgementType?.name ?? 'a').localeCompare(b.judgementType?.name ?? 'a')
+		},
+		{
+			title: 'Source Code',
+			renderer: SourceColumn,
+			rendererProps: (object: SubmissionData) => ({
+				source: object.files,
+				onclick: () =>
+					sourceModal?.openSource(
+						object.files,
+						object.team?.display_name || object.team?.name + ' source code',
+						object.auth
+					)
+			})
+		}
+	];
 
 	// svelte-ignore state_referenced_locally
 	if (data.hasReactions) {
-		columns.push(reactionColumn);
+		columns.push({
+			title: 'Reaction Video',
+			renderer: ReactionColumn,
+			rendererProps: (object: SubmissionData) => ({
+				reaction: object.reaction,
+				onclick: () =>
+					reactionModal?.openReaction(
+						object.reaction,
+						object.team?.display_name || object.team?.name + ' reaction video'
+					)
+			})
+		});
 	}
 </script>
 

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -2,7 +2,7 @@
 	import { goto, invalidate } from '$app/navigation';
 	import { PersonUI, Photo } from '@icpctools/contest-ui';
 	import { onMount } from 'svelte';
-	import { Column } from '$lib/ui/table/table';
+	import type { Column } from '$lib/ui/table/table';
 	import SimpleColumn from '$lib/ui/table/SimpleColumn.svelte';
 	import Table from '$lib/ui/table/Table.svelte';
 	import { timeToMin, parseRelTime } from '@icpctools/contest-api';
@@ -19,60 +19,63 @@
 	let sourceModal = $state<SourceModal>();
 	let reactionModal = $state<ReactionModal>();
 
-	let timeColumn = new Column<SubmissionData>('Time', {
-		renderer: SimpleColumn,
-		rendererProps: (object: SubmissionData) => ({ object: timeToMin(object.time) }),
-		comparator: (a, b): number => (parseRelTime(a.time) ?? 0) - (parseRelTime(b.time) ?? 0)
-	});
-
-	let problemColumn = new Column<SubmissionData>('Problem', {
-		renderer: ProblemColumn,
-		rendererProps: (object: SubmissionData) => ({
-			problem: object.problem,
-			onclick: () => goto(`/problem/${object.problem.id}`)
-		}),
-		comparator: (a, b): number => a.problem.ordinal - b.problem.ordinal
-	});
-
-	let languageColumn = new Column<SubmissionData>('Language', {
-		renderer: SimpleColumn,
-		rendererProps: (object: SubmissionData) => ({ object: object.language.name }),
-		comparator: (a, b): number => a.language.name.localeCompare(b.language.name)
-	});
-
-	let judgementTypeColumn = new Column<SubmissionData>('Judgement', {
-		renderer: JudgementTypeColumn,
-		rendererProps: (object: SubmissionData) => ({ judgementType: object.judgementType }),
-		comparator: (a, b): number => (a.judgementType?.name ?? 'a').localeCompare(b.judgementType?.name ?? 'a')
-	});
-
-	let sourceColumn = new Column<SubmissionData>('Source Code', {
-		renderer: SourceColumn,
-		rendererProps: (object: SubmissionData) => ({
-			source: object.files,
-			onclick: () =>
-				sourceModal?.openSource(
-					object.files,
-					object.team?.display_name || object.team?.name + ' source code',
-					object.auth
-				)
-		})
-	});
-
-	let reactionColumn = new Column<SubmissionData>('Reaction Video', {
-		renderer: ReactionColumn,
-		rendererProps: (object: SubmissionData) => ({
-			reaction: object.reaction,
-			onclick: () =>
-				reactionModal?.openReaction(object.reaction, object.team?.display_name || object.team?.name + ' reaction video')
-		})
-	});
-
-	const columns = [timeColumn, problemColumn, languageColumn, judgementTypeColumn, sourceColumn];
+	const columns: Column<SubmissionData>[] = [
+		{
+			title: 'Time',
+			renderer: SimpleColumn,
+			rendererProps: (object: SubmissionData) => ({ object: timeToMin(object.time) }),
+			comparator: (a, b): number => (parseRelTime(a.time) ?? 0) - (parseRelTime(b.time) ?? 0)
+		},
+		{
+			title: 'Problem',
+			renderer: ProblemColumn,
+			rendererProps: (object: SubmissionData) => ({
+				problem: object.problem,
+				onclick: () => goto(`/problem/${object.problem.id}`)
+			}),
+			comparator: (a, b): number => a.problem.ordinal - b.problem.ordinal
+		},
+		{
+			title: 'Language',
+			renderer: SimpleColumn,
+			rendererProps: (object: SubmissionData) => ({ object: object.language.name }),
+			comparator: (a, b): number => a.language.name.localeCompare(b.language.name)
+		},
+		{
+			title: 'Judgement',
+			renderer: JudgementTypeColumn,
+			rendererProps: (object: SubmissionData) => ({ judgementType: object.judgementType }),
+			comparator: (a, b): number => (a.judgementType?.name ?? 'a').localeCompare(b.judgementType?.name ?? 'a')
+		},
+		{
+			title: 'Source Code',
+			renderer: SourceColumn,
+			rendererProps: (object: SubmissionData) => ({
+				source: object.files,
+				onclick: () =>
+					sourceModal?.openSource(
+						object.files,
+						object.team?.display_name || object.team?.name + ' source code',
+						object.auth
+					)
+			})
+		}
+	];
 
 	// svelte-ignore state_referenced_locally
 	if (data.hasReactions) {
-		columns.push(reactionColumn);
+		columns.push({
+			title: 'Reaction Video',
+			renderer: ReactionColumn,
+			rendererProps: (object: SubmissionData) => ({
+				reaction: object.reaction,
+				onclick: () =>
+					reactionModal?.openReaction(
+						object.reaction,
+						object.team?.display_name || object.team?.name + ' reaction video'
+					)
+			})
+		});
 	}
 
 	onMount(() => {


### PR DESCRIPTION
Yeah, it's just another simplification of the tables. Now that we only have one type after the last simplification, there's no need to have both Column and ColumnInformation. Merging the two makes Table slightly simpler and allows json-object style definition of the columns instead of requiring a constructor.