### PR TITLE
feat: clarifications page

### DIFF
--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -451,6 +451,9 @@ export class ContestAPI {
 				if (this.judgements) {
 					await this.loadJudgements(true);
 				}
+				if (this.clarifications) {
+					await this.loadClarifications(true);
+				}
 				if (this.scoreboard) {
 					await this.loadScoreboard(true);
 				}

--- a/packages/contest-api/src/contest-util.ts
+++ b/packages/contest-api/src/contest-util.ts
@@ -21,7 +21,7 @@ export class ContestUtil {
 
 	findManyById<Type extends { id: string }>(
 		arr: Array<Type> | undefined,
-		ids: string | undefined
+		ids: string[] | undefined
 	): Array<Type> | undefined {
 		if (!arr || arr.length === 0 || !ids || ids.length == 0) {
 			return undefined;

--- a/src/lib/ui/ClarificationUI.svelte
+++ b/src/lib/ui/ClarificationUI.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { timeToMin } from '@icpctools/contest-api';
+	import type { ClarificationData } from '../../routes/clarifications/clarificationData';
+	import ClarificationUI from './ClarificationUI.svelte';
+
+	interface Props {
+		clar: ClarificationData;
+	}
+	let { clar }: Props = $props();
+</script>
+
+<div class="w-full py-2">
+	<div class="flex flex-row space-x-5">
+		<div>
+			From:
+			{#if clar.from_team}
+				{clar.from_team.display_name ?? clar.from_team.name}
+			{:else}
+				Jury
+			{/if}
+		</div>
+
+		{#if !clar.from_team}
+			<div>
+				To:
+				{#if clar.to_teams && clar.to_teams?.length > 0}
+					{#each clar.to_teams as team (team.id)}
+						<div>{team.display_name ?? team.name}</div>
+					{/each}
+				{/if}
+				{#if clar.to_groups && clar.to_groups?.length > 0}
+					{#each clar.to_groups as group (group.id)}
+						<div>{group.name}</div>
+					{/each}
+				{/if}
+				{#if !clar.from_team && !clar.to_teams && !clar.to_groups}
+					All
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<div class="flex flex-row w-full">
+		<div
+			class="rounded-xl bg-slate-200 dark:bg-slate-700 px-4 py-3 shadow-sm grow"
+			class:rounded-bl-xs={clar.from_team}
+			class:rounded-br-xs={!clar.from_team}>
+			{clar.text}
+		</div>
+		<div class="text-xs w-16 shrink-0 text-right">{timeToMin(clar.time)} min</div>
+	</div>
+
+	{#if clar.replies}
+		<div class="pl-20">
+			{#each clar.replies as reply (reply.id)}
+				<ClarificationUI clar={reply} />
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -46,6 +46,11 @@
 		{/if}
 
 		<div class="text-lg hover:bg-hover hover:text-link p-2 rounded-md">
+			<a href="/clarifications" class="flex flex-row items-center"
+				><i class="fa-regular fa-clipboard-question pr-2"></i>Clarifications</a>
+		</div>
+
+		<div class="text-lg hover:bg-hover hover:text-link p-2 rounded-md">
 			<a href="/scoreboard" class="flex flex-row items-center"
 				><i class="fa-regular fa-square-poll-horizontal pr-2"></i>Scoreboard</a>
 		</div>

--- a/src/routes/clarifications/+page.server.ts
+++ b/src/routes/clarifications/+page.server.ts
@@ -1,0 +1,61 @@
+import { error } from '@sveltejs/kit';
+import { loadContest } from '$lib/state.svelte.js';
+import type { ClarificationData } from './clarificationData.js';
+import { ContestUtil, type Clarification, type Group, type Problem, type Team } from '@icpctools/contest-api';
+
+function createClarData(c: Clarification, util: ContestUtil, teams: Team[], groups: Group[], problems: Problem[]) {
+	return {
+		id: c.id,
+		time: c.contest_time,
+		text: c.text,
+		from_team: util.findById(teams, c.from_team_id),
+		to_teams: util.findManyById(teams, c.to_team_ids),
+		to_groups: util.findManyById(groups, c.to_group_ids),
+		problem: util.findById(problems, c.problem_id)
+	} as ClarificationData;
+}
+
+export const load = async ({ depends }) => {
+	depends('data:clarifications');
+	const cc = await loadContest();
+	if (!cc) throw error(404);
+
+	await Promise.all([cc.loadGroups(), cc.loadTeams(), cc.loadProblems(), cc.loadClarifications()]);
+
+	const problems = cc.getProblems();
+
+	const teams = cc.getTeams();
+
+	const groups = cc.getGroups();
+
+	const clars = cc.getClarifications();
+
+	const util = new ContestUtil();
+
+	const clarDataMap = new Map<string, ClarificationData>();
+	for (const c of clars ?? []) {
+		clarDataMap.set(c.id, createClarData(c, util, teams, groups, problems));
+	}
+
+	// Attach replies as children of their parent
+	const rootClars: ClarificationData[] = [];
+	for (const c of clars ?? []) {
+		const data = clarDataMap.get(c.id)!;
+		const parentId = c.reply_to_id;
+		if (parentId) {
+			const parent = clarDataMap.get(parentId);
+			if (parent) {
+				parent.replies ??= [];
+				parent.replies.push(data);
+			} else {
+				rootClars.push(data);
+			}
+		} else {
+			rootClars.push(data);
+		}
+	}
+
+	return {
+		clarifications: rootClars
+	};
+};

--- a/src/routes/clarifications/+page.svelte
+++ b/src/routes/clarifications/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { invalidate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import ClarificationUI from '$lib/ui/ClarificationUI.svelte';
+
+	let { data } = $props();
+
+	onMount(() => {
+		const interval = setInterval(() => {
+			invalidate('data:problem');
+		}, 3000);
+
+		return () => {
+			clearInterval(interval);
+		};
+	});
+</script>
+
+<div class="flex flex-col p-2 gap-1 h-full overflow-auto bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+	<div class="flex flex-col">
+		<div class="text-xl">Clarifications</div>
+
+		{#if data.clarifications.length === 0}
+			<div>None</div>
+		{/if}
+
+		{#each data.clarifications as clar (clar.id)}
+			<ClarificationUI {clar} />
+		{/each}
+	</div>
+</div>

--- a/src/routes/clarifications/clarificationData.ts
+++ b/src/routes/clarifications/clarificationData.ts
@@ -1,0 +1,12 @@
+import type { Group, Problem, RelTime, Team } from '@icpctools/contest-api';
+
+export interface ClarificationData {
+	id: string;
+	time: RelTime;
+	text: string;
+	problem?: Problem;
+	from_team?: Team;
+	to_teams?: Team[];
+	to_groups?: Group[];
+	replies?: ClarificationData[];
+}


### PR DESCRIPTION
Adds clarifications to the main toolbar, with a page that shows a simple 'threaded' view of each clarification and response. Pretty simple for now but could be expanded or made prettier later.

Fixes #139.