### PR TITLE
chore: fix 0.7 version bump

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,8 +84,9 @@ jobs:
           git checkout -b "${bumpedBranchName}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${bumpedVersion}-next\",#g" package.json
           find packages/* -maxdepth 1 -name "package.json" | xargs -I {} sed -i "s#version\":\ \"\(.*\)\",#version\":\ \"${bumpedVersion}-next\",#g" {}
+          git add package.json packages/*/package.json
 
-          git add package.json packages/contest-api/package.json
+          # commit the changes
           git commit -s --amend -m "chore: bump version to ${bumpedVersion}"
           git push origin "${bumpedBranchName}"
           echo -e "Bump version to ${bumpedVersion}\n\n${{ steps.tag_util.outputs.releaseVersion }} has been released.\n\n Time to switch to the new ${bumpedVersion} version" > /tmp/pr-title

--- a/packages/contest-ui/package.json
+++ b/packages/contest-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@icpctools/contest-ui",
-	"version": "0.7.0",
+	"version": "0.8.0-next",
 	"license": "MIT",
 	"type": "module",
 	"main": "./src/index.ts",


### PR DESCRIPTION
The 0.7.0 release workflow didn't bump the contest-ui package in PR #146. This bumps the package, and fixes the workflow for next time. Changed the spacing and added comment to match the two places we do this in the workflow to make future comparison /changes easier.