### PR TITLE
chore: correctly display images

### DIFF
--- a/packages/contest-ui/src/lib/Banner.svelte
+++ b/packages/contest-ui/src/lib/Banner.svelte
@@ -9,8 +9,17 @@
 	}
 
 	let { ref, size = 16, tag }: Props = $props();
+
+	const sizeClasses: Record<number, string> = {
+		/* eslint-disable @typescript-eslint/naming-convention */
+		16: 'max-h-16 h-16',
+		24: 'max-h-24 h-24',
+		32: 'max-h-32 h-32',
+		64: 'max-h-64 h-64'
+		/* eslint-enable @typescript-eslint/naming-convention */
+	};
 </script>
 
-<div class="max-h-{size} h-{size} flex place-content-center">
+<div class="{sizeClasses[size] ?? ''} flex items-center justify-center">
 	<Image {ref} {size} {tag} />
 </div>

--- a/packages/contest-ui/src/lib/Image.svelte
+++ b/packages/contest-ui/src/lib/Image.svelte
@@ -21,5 +21,5 @@
 </script>
 
 {#if imgSrc}
-	<img src={imgSrc} alt="logo" class="w-full h-full object-scale-down rounded-md" onerror={onError} />
+	<img src={imgSrc} alt="logo" class="max-w-full max-h-full object-scale-down rounded-md" onerror={onError} />
 {/if}

--- a/packages/contest-ui/src/lib/Logo.svelte
+++ b/packages/contest-ui/src/lib/Logo.svelte
@@ -9,8 +9,19 @@
 	}
 
 	let { ref, size = 8, tag }: Props = $props();
+
+	// Tailwind v4 can't detect dynamically constructed class names,
+	// so we map size values to static strings it can scan.
+	const sizeClasses: Record<number, string> = {
+		/* eslint-disable @typescript-eslint/naming-convention */
+		4: 'max-h-4 max-w-4 h-4 w-4',
+		8: 'max-h-8 max-w-8 h-8 w-8',
+		16: 'max-h-16 max-w-16 h-16 w-16',
+		24: 'max-h-24 max-w-24 h-24 w-24'
+		/* eslint-enable @typescript-eslint/naming-convention */
+	};
 </script>
 
-<div class="max-h-{size} max-w-{size} h-{size} w-{size} flex place-content-center">
+<div class="{sizeClasses[size] ?? ''} flex items-center justify-center">
 	<Image {ref} {size} {tag} />
 </div>

--- a/packages/contest-ui/src/lib/PersonUI.svelte
+++ b/packages/contest-ui/src/lib/PersonUI.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <div class="flex flex-col items-center border bg-gray-200 dark:bg-gray-900 gap-2">
-	<div class="flex flex-col w-32 h-44 place-content-center">
+	<div class="flex flex-col w-32 h-44 items-center justify-center">
 		{#if person.photo && person.photo.length > 0}
 			<Image ref={person.photo} size={24} />
 		{:else}

--- a/packages/contest-ui/src/lib/Photo.svelte
+++ b/packages/contest-ui/src/lib/Photo.svelte
@@ -8,8 +8,16 @@
 	}
 
 	let { ref, size = 24 }: Props = $props();
+
+	const sizeClasses: Record<number, string> = {
+		/* eslint-disable @typescript-eslint/naming-convention */
+		8: 'max-h-8 max-w-8 h-8 w-8',
+		16: 'max-h-16 max-w-16 h-16 w-16',
+		24: 'max-h-24 max-w-24 h-24 w-24'
+		/* eslint-enable @typescript-eslint/naming-convention */
+	};
 </script>
 
-<div class="max-h-{size} max-w-{size} h-{size} w-{size} flex place-content-center">
+<div class="{sizeClasses[size] ?? ''} flex items-center justify-center">
 	<Image {ref} {size} />
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,7 +13,7 @@
 				<div class="flex flex-row gap-2 items-center">
 					{#if data.logos[i]}
 						<div
-							class="bg-gray-400 dark:bg-gray-600 rounded-md max-w-12 min-w-12 max-h-12 min-h-12 w-12 h-12 p-1 flex place-content-center">
+							class="bg-gray-400 dark:bg-gray-600 rounded-md max-w-12 min-w-12 max-h-12 min-h-12 w-12 h-12 p-1 flex items-center justify-center">
 							<Logo ref={data.logos[i]} />
 						</div>
 					{/if}

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,3 +1,4 @@
 @import 'tailwindcss';
+@source "../packages/contest-ui/src";
 
 @custom-variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
The Tailwind compiler drops dynamic classes, so we need to add them.

Also make sure images are centered vertically.