### PR TITLE
feat: optional proxy server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ The app connects to a Contest API server via environment variables (or edit `src
 - `CONTEST_USER` - Contest server user
 - `CONTEST_PASSWORD` - User password
 
+- `CONTEST_PROXY` - Enable Contest API proxying by setting to 'true'
+
 ## Architecture
 
 ### Monorepo Structure
@@ -109,6 +111,22 @@ SvelteKit file-based routing:
 - `/map` - Floor map showing team locations
 - `/problem/[id]` - Problem details
 - `/clarifications` - Clarification requests
+- `/proxy/[...path]` - Server-side proxy to `CONTEST_URL/*` (GET requests only, authenticated)
+
+### API Proxy
+
+The `/proxy/*` route (`src/routes/proxy/[...path]/+server.ts`) acts as a server-side streaming proxy:
+
+- Client requests to `/proxy/contests/123` are proxied to `CONTEST_URL/contests/123`
+- Currently supports GET requests only (returns 501 for other methods)
+- **Streaming support** - Uses `got.stream()` to stream responses without buffering (enables MPEG-TS video and other large/streaming content)
+- Forwards request headers (excluding host, connection, content-length)
+- Includes HTTP Basic Auth using `CONTEST_USER` and `CONTEST_PASSWORD` from environment variables
+- **Accepts self-signed/invalid SSL certificates** (`rejectUnauthorized: false`) for development environments
+- Returns proxied response with appropriate headers and status codes
+- Handles errors with 502 Bad Gateway status
+
+This allows client-side code to call `/proxy/...` endpoints without CORS issues while streaming video and other large responses efficiently.
 
 ## Development Workflow
 

--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -69,22 +69,31 @@ export class ContestAPI {
 
 	private unknownTypes: string[] = [];
 
-	constructor(contestURL: string, credentials?: Credentials) {
+	constructor(contestURL: string, credentials?: Credentials, proxyURL?: string) {
 		if (!contestURL.endsWith('/')) {
 			contestURL += '/';
 		}
 		this.contestURL = contestURL;
 		this.credentials = credentials;
 
-		// base url, e.g. http://example.com/api/
 		const bInd = this.contestURL.indexOf('/api/contests/');
-		this.baseURL = this.contestURL.substring(0, bInd + 5);
 		this.id = this.contestURL.substring(bInd + 14, this.contestURL.length - 1);
 
+		// base url, e.g. http://example.com/api/
+		if (proxyURL) {
+			this.baseURL = proxyURL + '/';
+		} else {
+			this.baseURL = this.contestURL.substring(0, bInd + 5);
+		}
+
 		// server url, e.g. http://example.com
-		const sInd = this.contestURL.indexOf('//');
-		const sInd2 = this.contestURL.indexOf('/', sInd + 2);
-		this.serverURL = this.contestURL.substring(0, sInd2);
+		if (proxyURL) {
+			this.serverURL = proxyURL + '/api';
+		} else {
+			const sInd = this.contestURL.indexOf('//');
+			const sInd2 = this.contestURL.indexOf('/', sInd + 2);
+			this.serverURL = this.contestURL.substring(0, sInd2);
+		}
 
 		//console.log('Contest URL: ' + this.contestURL);
 	}

--- a/packages/contest-api/src/contests.ts
+++ b/packages/contest-api/src/contests.ts
@@ -11,13 +11,15 @@ export class Contests {
 	contestObjs: Contest[] | undefined;
 	baseURL: string;
 	credentials?: Credentials;
+	proxyURL?: string;
 
-	constructor(baseURL: string, credentials?: Credentials) {
+	constructor(baseURL: string, credentials?: Credentials, proxyURL?: string) {
 		if (!baseURL.endsWith('/')) {
 			baseURL += '/';
 		}
 		this.baseURL = baseURL;
 		this.credentials = credentials;
+		this.proxyURL = proxyURL;
 		console.log('Contest API URL: ' + this.baseURL);
 	}
 
@@ -88,7 +90,7 @@ export class Contests {
 		} else {
 			contestURL += this.contests[0].id;
 		}
-		return new ContestAPI(contestURL, this.credentials);
+		return new ContestAPI(contestURL, this.credentials, this.proxyURL);
 	}
 
 	getContestObjs(): Contest[] | undefined {

--- a/src/lib/hardcoded.svelte.ts
+++ b/src/lib/hardcoded.svelte.ts
@@ -10,3 +10,7 @@ export const CONTEST = $state(
 				password: process?.env?.CONTEST_PASSWORD || 'adm1n'
 			}
 );
+
+export const CONFIG = $state({
+	proxy: process?.env?.CONTEST_PROXY ? process?.env?.CONTEST_PROXY === 'true' : process.env.NODE_ENV === 'development'
+});

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,6 +1,6 @@
 import type { ContestAPI } from '@icpctools/contest-api';
 import { Contests } from '@icpctools/contest-api';
-import { CONTEST } from './hardcoded.svelte';
+import { CONFIG, CONTEST } from './hardcoded.svelte';
 
 let contest: ContestAPI | undefined;
 
@@ -37,10 +37,18 @@ export async function loadContest(): Promise<ContestAPI | undefined> {
 			throw new Error('CONTEST.url is not defined');
 		}
 
-		const contests = new Contests(CONTEST.url, {
-			user: CONTEST.user,
-			password: CONTEST.password
-		});
+		if (CONFIG.proxy) {
+			console.log('Proxy server enabled');
+		}
+
+		const contests = new Contests(
+			CONTEST.url,
+			{
+				user: CONTEST.user,
+				password: CONTEST.password
+			},
+			CONFIG.proxy ? '/proxy' : undefined
+		);
 		await contests.loadContests();
 
 		if (!contests) {

--- a/src/routes/proxy/[...path]/+server.ts
+++ b/src/routes/proxy/[...path]/+server.ts
@@ -1,0 +1,91 @@
+import { CONFIG, CONTEST } from '$lib/hardcoded.svelte';
+import type { RequestHandler } from './$types';
+import got from 'got';
+import { Readable } from 'node:stream';
+
+// Proxy will only support GET for now
+export const GET: RequestHandler = async ({ params, url, request }) => {
+	if (!CONFIG.proxy) {
+		return new Response(JSON.stringify({ error: 'Proxy not enabled' }), {
+			status: 502,
+			headers: { 'Content-Type': 'application/json' }
+		});
+	}
+	return proxyRequest(params.path, url, request);
+};
+
+async function proxyRequest(path: string, url: URL, request: Request): Promise<Response> {
+	// Build the target URL
+	const serverURL = CONTEST.url?.endsWith('/') ? CONTEST.url : CONTEST.url + '/';
+	const targetUrl = `${serverURL}${path}${url.search}`;
+
+	// Copy headers, excluding some that shouldn't be forwarded
+	const headers: Record<string, string> = {};
+	const excludedHeaders = ['host', 'connection', 'content-length'];
+
+	for (const [key, value] of request.headers.entries()) {
+		if (!excludedHeaders.includes(key.toLowerCase())) {
+			headers[key] = value;
+		}
+	}
+
+	try {
+		// Create a streaming request (supports MPEG-TS video and other streams)
+		const stream = got.stream(targetUrl, {
+			method: request.method as 'GET',
+			headers,
+			https: {
+				rejectUnauthorized: false // Accept self-signed certificates
+			},
+			username: CONTEST.user || undefined,
+			password: CONTEST.password || undefined,
+			throwHttpErrors: false, // Don't throw on non-2xx status codes
+			followRedirect: true
+		});
+
+		// Wait for response headers, then stream the body
+		return new Promise<Response>((resolve) => {
+			stream.on('response', (response) => {
+				// Copy response headers
+				const responseHeaders = new Headers();
+				for (const [key, value] of Object.entries(response.headers)) {
+					// Skip headers that shouldn't be forwarded
+					if (!['connection', 'keep-alive', 'transfer-encoding'].includes(key.toLowerCase())) {
+						if (Array.isArray(value)) {
+							value.forEach((v) => responseHeaders.append(key, v));
+						} else if (value !== undefined) {
+							responseHeaders.set(key, String(value));
+						}
+					}
+				}
+
+				// Convert Node.js stream to Web ReadableStream for streaming response
+				const webStream = Readable.toWeb(stream as Readable) as ReadableStream;
+
+				resolve(
+					new Response(webStream as BodyInit, {
+						status: response.statusCode || 200,
+						statusText: response.statusMessage || 'OK',
+						headers: responseHeaders
+					})
+				);
+			});
+
+			stream.on('error', (error) => {
+				console.error('Proxy stream error:', error);
+				resolve(
+					new Response(JSON.stringify({ error: 'Proxy request failed' }), {
+						status: 502,
+						headers: { 'Content-Type': 'application/json' }
+					})
+				);
+			});
+		});
+	} catch (error) {
+		console.error('Proxy error:', error);
+		return new Response(JSON.stringify({ error: 'Proxy request failed' }), {
+			status: 502,
+			headers: { 'Content-Type': 'application/json' }
+		});
+	}
+}


### PR DESCRIPTION
Adds an optional proxy server to the team view. When enabled, team view responds to GET requests on /proxy and forwards all requests to the configured Contest API server with the same user and password given for the Contest API. The contest-api is also auto-configured to route all file references with server- and base- relative requests through the proxy instead of directly to the original server.

This allows the proxy to respond to requests for things like logos, photos, or video streams without any cross-origin related issues or requiring the server to have a valid certificate. The drawback is all traffic goes through the team view, which greatly increases the volume of HTTP traffic.

The proxy is primarily meant to simplify development for now, and has not been explicitly hardened for production use (no filtering, no caching, etc). As such it is on by default in development and off by default in production builds. It can be explicitly configured via the CONTEST_PROXY env (internally CONFIG.proxy b/c this is more configuration related).

Fixes #175.