### PR TITLE
chore: minor table improvements

### DIFF
--- a/src/lib/ui/table/SimpleColumn.svelte
+++ b/src/lib/ui/table/SimpleColumn.svelte
@@ -5,6 +5,6 @@
 	let { object }: Props = $props();
 </script>
 
-<div class="text-black dark:text-white max-w-full px-1 text-wrap">
+<div class="text-black dark:text-white max-w-full overflow-hidden text-ellipsis">
 	{object}
 </div>

--- a/src/lib/ui/table/Table.svelte
+++ b/src/lib/ui/table/Table.svelte
@@ -106,11 +106,11 @@
 					<!-- svelte-ignore a11y_interactive_supports_focus -->
 					<div
 						class={{
-							'flex max-w-full overflow-hidden text-sm font-semibold whitespace-nowrap select-none self-center': true,
-							'justify-self-start': column.align === 'left',
-							'justify-self-center': column.align === 'center',
-							'justify-self-end': column.align === 'right',
-							'justify-self-stretch': column.align === 'stretch',
+							'flex items-center max-w-full overflow-hidden text-sm font-semibold whitespace-nowrap select-none': true,
+							'justify-self-start': (column.titleAlign ?? column.align) === 'left',
+							'justify-self-center': (column.titleAlign ?? column.align) === 'center',
+							'justify-self-end': (column.titleAlign ?? column.align) === 'right',
+							'justify-self-stretch': (column.titleAlign ?? column.align) === 'stretch',
 							'cursor-pointer': column.comparator,
 							'hover:text-black': sortCol !== column,
 							'hover:dark:text-white': sortCol !== column
@@ -151,25 +151,24 @@
 	<!-- Rows -->
 	<div role="rowgroup" class="relative">
 		{#each data2 as object, rowIndex (object?.[keyProperty])}
-			<div class="min-h-10 h-fit relative" animate:flip={{ duration: 1500 }}>
-				<div
-					class="grid grid-table gap-x-0.5 min-h-10 hover:bg-gray-300/80 dark:hover:bg-gray-800/80 rounded-lg"
-					role="row">
-					{#each columns as column, colIndex (colIndex)}
-						<div
-							class={{
-								'flex items-center self-stretch max-w-full py-px whitespace-nowrap': true,
-								'justify-self-start': column.align === 'left',
-								'justify-self-center': column.align === 'center',
-								'justify-self-end': column.align === 'right',
-								'justify-self-stretch': column.align === 'stretch',
-								'overflow-hidden': column.overflow === true
-							}}
-							role="cell">
-							<column.renderer {...column.rendererProps?.(object, rowIndex)} />
-						</div>
-					{/each}
-				</div>
+			<div
+				class="grid grid-table gap-x-0.5 min-h-10 ml-1 hover:bg-gray-300/80 dark:hover:bg-gray-800/80 rounded-lg relative"
+				animate:flip={{ duration: 1500 }}
+				role="row">
+				{#each columns as column, colIndex (colIndex)}
+					<div
+						class={{
+							'flex items-center max-w-full py-px whitespace-nowrap': true,
+							'justify-self-start': column.align === 'left',
+							'justify-self-center': column.align === 'center',
+							'justify-self-end': column.align === 'right',
+							'justify-self-stretch': column.align === 'stretch',
+							'overflow-hidden': column.overflow !== true
+						}}
+						role="cell">
+						<column.renderer {...column.rendererProps?.(object, rowIndex)} />
+					</div>
+				{/each}
 			</div>
 		{/each}
 	</div>

--- a/src/lib/ui/table/TeamColumn.svelte
+++ b/src/lib/ui/table/TeamColumn.svelte
@@ -15,12 +15,14 @@
 	<button
 		{onclick}
 		class={{
-			'flex flex-row items-center text-black dark:text-white p-0.5 gap-x-2 rounded': true,
+			'flex flex-row items-center text-black dark:text-white p-0.5 gap-x-2 rounded max-w-full': true,
 			'cursor-pointer hover:bg-hover': onclick
 		}}>
-		{#if logo || !noGap}
-			<Logo ref={logo} />
-		{/if}
-		{team.display_name || team.name}
+		<div class="flex flex-row items-center gap-x-2 max-w-full">
+			{#if logo || !noGap}
+				<div class="w-6"><Logo ref={logo} /></div>
+			{/if}
+			<span class="overflow-hidden text-ellipsis">{team.display_name || team.name}</span>
+		</div>
 	</button>
 {/if}

--- a/src/lib/ui/table/table.ts
+++ b/src/lib/ui/table/table.ts
@@ -18,6 +18,13 @@ export interface Column<Type> {
 	readonly titleProps?: Record<string, unknown>;
 
 	/**
+	 * Title alignment, one of 'left', 'center', 'right', or 'stretch',
+	 *
+	 * Defaults to column alignment.
+	 */
+	readonly titleAlign?: 'left' | 'center' | 'right' | 'stretch';
+
+	/**
 	 * Column alignment, one of 'left', 'center', 'right', or 'stretch',
 	 *
 	 * Defaults to 'left' alignment.


### PR DESCRIPTION
While continuing to try to use Table for scoreboards, I found a few minor issues:
- There was no way to centre a column title but use different alignment on the cells (e.g. Problem 'A' centred as a title but cells taking full width), so added this.
- A === instead of !== meant that all table cells were allowed to overflow their cells, so when you shrink the width things looked awful. Fixed.
- When columns are narrow, SimpleColumn and TeamColumn would just crop text. Made sure the team logo stays the correct size and text uses ellipsis.
- The table left margin only looked ok because simple column had a px-1; added this to the table row instead. Merged unnecessary two divs.