### PR TITLE
chore: server-sent events for contest changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ SvelteKit file-based routing:
 - `/problem/[id]` - Problem details
 - `/clarifications` - Clarification requests
 - `/proxy/[...path]` - Server-side proxy to `CONTEST_URL/*` (GET requests only, authenticated)
+- `/api/events` - Server-Sent Events endpoint for real-time contest updates
 
 ### API Proxy
 
@@ -127,6 +128,28 @@ The `/proxy/*` route (`src/routes/proxy/[...path]/+server.ts`) acts as a server-
 - Handles errors with 502 Bad Gateway status
 
 This allows client-side code to call `/proxy/...` endpoints without CORS issues while streaming video and other large responses efficiently.
+
+### Server-Sent Events (SSE)
+
+The `/api/events` route provides real-time contest updates via Server-Sent Events:
+
+- **ContestAPI Change Listeners** - The `ContestAPI` class supports registering change listeners that fire when contest data changes
+- **Event Types** - Emits events for all contest data types: `contest`, `state`, `teams`, `submissions`, `judgements`, `clarifications`, `scoreboard`, etc.
+- **Event Structure** - `{ type: string, id?: string }`
+- **Auto-cleanup** - Listeners are automatically removed when clients disconnect
+- **Keep-alive** - Sends ping every 30 seconds to maintain connection
+
+Client usage:
+
+```typescript
+const eventSource = new EventSource('/api/events');
+eventSource.onmessage = (event) => {
+	const change = JSON.parse(event.data);
+	// { type: 'submissions', id: '123' }
+};
+```
+
+The main page (`src/routes/+layout.svelte`) uses SSE with SvelteKit's `invalidate()` to automatically refresh pages when contest data changes.
 
 ## Development Workflow
 

--- a/packages/contest-api/src/contest-api.test.ts
+++ b/packages/contest-api/src/contest-api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { ContestAPI } from './contest-api.js';
+import { ContestAPI, ContestEvent } from './contest-api.js';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { Response } from 'got';
@@ -163,4 +163,101 @@ test('getAuth', () => {
 test('getTimeDelta', () => {
 	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
 	expect(contestAPI.getTimeDelta()).toBe(0);
+});
+
+test('addChangeListener and fireChange', () => {
+	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
+	const events: ContestEvent[] = [];
+
+	const listener = (event: ContestEvent) => {
+		events.push(event);
+	};
+
+	contestAPI.addChangeListener(listener);
+
+	// Simulate a notification
+	contestAPI.processNotification({
+		type: 'teams',
+		id: '123'
+	});
+
+	expect(events.length).toBe(1);
+	expect(events[0].type).toBe('teams');
+	expect(events[0].id).toBe('123');
+});
+
+test('removeChangeListener', () => {
+	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
+	const events: ContestEvent[] = [];
+
+	const listener = (event: ContestEvent) => {
+		events.push(event);
+	};
+
+	contestAPI.addChangeListener(listener);
+	contestAPI.removeChangeListener(listener);
+
+	// Simulate a notification
+	contestAPI.processNotification({
+		type: 'teams',
+		id: '123'
+	});
+
+	expect(events.length).toBe(0);
+});
+
+test('multiple listeners receive events', () => {
+	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
+	const events1: ContestEvent[] = [];
+	const events2: ContestEvent[] = [];
+
+	const listener1 = (event: ContestEvent) => {
+		events1.push(event);
+	};
+
+	const listener2 = (event: ContestEvent) => {
+		events2.push(event);
+	};
+
+	contestAPI.addChangeListener(listener1);
+	contestAPI.addChangeListener(listener2);
+
+	// Simulate a notification
+	contestAPI.processNotification({
+		type: 'submissions',
+		id: '456'
+	});
+
+	expect(events1.length).toBe(1);
+	expect(events2.length).toBe(1);
+	expect(events1[0].type).toBe('submissions');
+	expect(events2[0].type).toBe('submissions');
+});
+
+test('listener errors do not break other listeners', () => {
+	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
+	const events: ContestEvent[] = [];
+	const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+	const errorListener = () => {
+		throw new Error('Listener error');
+	};
+
+	const goodListener = (event: ContestEvent) => {
+		events.push(event);
+	};
+
+	contestAPI.addChangeListener(errorListener);
+	contestAPI.addChangeListener(goodListener);
+
+	// Simulate a notification
+	contestAPI.processNotification({
+		type: 'teams',
+		id: '123'
+	});
+
+	expect(events.length).toBe(1);
+	expect(consoleErrorSpy).toHaveBeenCalled();
+
+	consoleErrorSpy.mockRestore();
 });

--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -34,6 +34,13 @@ export interface Credentials {
 	password?: string;
 }
 
+export type ContestEvent = {
+	type: string;
+	id?: Id;
+};
+
+export type ContestListener = (event: ContestEvent) => void;
+
 export class ContestAPI {
 	private contest?: Contest;
 	private access?: Access;
@@ -68,6 +75,8 @@ export class ContestAPI {
 	private interval: number | NodeJS.Timeout | undefined;
 
 	private unknownTypes: string[] = [];
+
+	private changeListeners: ContestListener[] = [];
 
 	constructor(contestURL: string, credentials?: Credentials, proxyURL?: string) {
 		if (!contestURL.endsWith('/')) {
@@ -177,36 +186,42 @@ export class ContestAPI {
 	async loadContest(force?: boolean): Promise<void> {
 		if (force || !this.contest) {
 			this.contest = await this.loadObject('');
+			this.fireChange({ type: 'contest' });
 		}
 	}
 
 	async loadAccess(force?: boolean): Promise<void> {
 		if (force || !this.access) {
 			this.access = await this.loadObject('access');
+			this.fireChange({ type: 'access' });
 		}
 	}
 
 	async loadState(force?: boolean): Promise<void> {
 		if (force || !this.state) {
 			this.state = await this.loadObject('state');
+			this.fireChange({ type: 'state' });
 		}
 	}
 
 	async loadStartStatus(force?: boolean): Promise<void> {
 		if (force || !this.startStatus) {
 			this.startStatus = await this.loadObject('start-status');
+			this.fireChange({ type: 'start-status' });
 		}
 	}
 
 	async loadLanguages(force?: boolean): Promise<void> {
 		if (force || !this.languages) {
 			this.languages = await this.loadObject('languages');
+			this.fireChange({ type: 'languages' });
 		}
 	}
 
 	async loadJudgementTypes(force?: boolean): Promise<void> {
 		if (force || !this.judgementTypes) {
 			this.judgementTypes = await this.loadObject('judgement-types');
+			this.fireChange({ type: 'judgement-types' });
 		}
 	}
 
@@ -217,18 +232,21 @@ export class ContestAPI {
 	async loadProblems(force?: boolean): Promise<void> {
 		if (force || !this.problems) {
 			this.problems = this.sortProblems(await this.loadObject('problems'));
+			this.fireChange({ type: 'problems' });
 		}
 	}
 
 	async loadGroups(force?: boolean): Promise<void> {
 		if (force || !this.groups) {
 			this.groups = await this.loadObject('groups');
+			this.fireChange({ type: 'groups' });
 		}
 	}
 
 	async loadOrganizations(force?: boolean): Promise<void> {
 		if (force || !this.organizations) {
 			this.organizations = await this.loadObject('organizations');
+			this.fireChange({ type: 'organizations' });
 		}
 	}
 
@@ -249,54 +267,63 @@ export class ContestAPI {
 	async loadTeams(force?: boolean): Promise<void> {
 		if (force || !this.teams) {
 			this.teams = this.sortTeams(await this.loadObject('teams'));
+			this.fireChange({ type: 'teams' });
 		}
 	}
 
 	async loadPersons(force?: boolean): Promise<void> {
 		if (force || !this.persons) {
 			this.persons = await this.loadObject('persons');
+			this.fireChange({ type: 'persons' });
 		}
 	}
 
 	async loadAccounts(force?: boolean): Promise<void> {
 		if (force || !this.accounts) {
 			this.accounts = await this.loadObject('accounts');
+			this.fireChange({ type: 'accounts' });
 		}
 	}
 
 	async loadAccount(force?: boolean): Promise<void> {
 		if (force || !this.account) {
 			this.account = await this.loadObject('account');
+			this.fireChange({ type: 'account' });
 		}
 	}
 
 	async loadSubmissions(force?: boolean): Promise<void> {
 		if (force || !this.submissions) {
 			this.submissions = await this.loadObject('submissions');
+			this.fireChange({ type: 'submissions' });
 		}
 	}
 
 	async loadJudgements(force?: boolean): Promise<void> {
 		if (force || !this.judgements) {
 			this.judgements = await this.loadObject('judgements');
+			this.fireChange({ type: 'judgements' });
 		}
 	}
 
 	async loadRuns(force?: boolean): Promise<void> {
 		if (force || !this.runs) {
 			this.runs = await this.loadObject('runs');
+			this.fireChange({ type: 'runs' });
 		}
 	}
 
 	async loadClarifications(force?: boolean): Promise<void> {
 		if (force || !this.clarifications) {
 			this.clarifications = await this.loadObject('clarifications');
+			this.fireChange({ type: 'clarifications' });
 		}
 	}
 
 	async loadCommentary(force?: boolean): Promise<void> {
 		if (force || !this.commentary) {
 			this.commentary = await this.loadObject('commentary');
+			this.fireChange({ type: 'commentary' });
 		}
 	}
 
@@ -308,18 +335,21 @@ export class ContestAPI {
 			});
 
 			this.scoreboard = scoreboard2;
+			this.fireChange({ type: 'scoreboard' });
 		}
 	}
 
 	async loadAwards(force?: boolean): Promise<void> {
 		if (force || !this.awards) {
 			this.awards = await this.loadObject('awards');
+			this.fireChange({ type: 'awards' });
 		}
 	}
 
 	async loadMapInfo(force?: boolean): Promise<void> {
 		if (force || !this.mapInfo) {
 			this.mapInfo = await this.loadObject('map-info');
+			this.fireChange({ type: 'map-info' });
 		}
 	}
 
@@ -536,6 +566,7 @@ export class ContestAPI {
 		if ((!n.id || n.type === 'contest') && !Array.isArray(n.data)) {
 			// no id and not an array: must be a 'singleton' object (e.g. state)
 			this.processNotificationSingleton(n.type, n.data ?? {});
+			this.fireChange({ type: n.type, id: n.id });
 			return;
 		}
 
@@ -608,6 +639,8 @@ export class ContestAPI {
 				}
 			}
 		}
+
+		this.fireChange({ type: n.type, id: n.id });
 	}
 
 	watch(): void {
@@ -644,5 +677,26 @@ export class ContestAPI {
 			return;
 		}
 		clearInterval(this.interval);
+	}
+
+	addChangeListener(listener: ContestListener): void {
+		this.changeListeners.push(listener);
+	}
+
+	removeChangeListener(listener: ContestListener): void {
+		const index = this.changeListeners.indexOf(listener);
+		if (index >= 0) {
+			this.changeListeners.splice(index, 1);
+		}
+	}
+
+	private fireChange(event: ContestEvent): void {
+		for (const listener of this.changeListeners) {
+			try {
+				listener(event);
+			} catch (error) {
+				console.error('Error in change listener:', error);
+			}
+		}
 	}
 }

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -6,7 +6,7 @@ export const load = async ({ depends }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	depends('data:contest');
+	depends('app:contest');
 
 	await Promise.all([cc.loadContest(), cc.loadAccess()]);
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,16 +6,34 @@
 	import '@fortawesome/fontawesome-free/css/all.min.css';
 	import { invalidate } from '$app/navigation';
 	import { ModeWatcher } from 'mode-watcher';
+	import type { ContestEvent } from '@icpctools/contest-api';
 
 	let { data, children } = $props();
 
 	onMount(() => {
-		const interval = setInterval(() => {
-			invalidate('data:contest');
-		}, 5000);
+		const eventSource = new EventSource('/api/events');
+
+		eventSource.onmessage = (event) => {
+			try {
+				const change: ContestEvent = JSON.parse(event.data);
+
+				// invalidate any page containing the specific object or all objects of that type
+				if (change.id) {
+					invalidate('app:' + change.type + '/' + change.id);
+				}
+				invalidate('app:' + change.type);
+			} catch (error) {
+				console.error('Error processing SSE event:', error);
+			}
+		};
+
+		eventSource.onerror = (error) => {
+			console.error('SSE connection error:', error);
+			eventSource.close();
+		};
 
 		return () => {
-			clearInterval(interval);
+			eventSource.close();
 		};
 	});
 </script>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -2,7 +2,9 @@ import { error } from '@sveltejs/kit';
 import { findById } from '@icpctools/contest-api';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async () => {
+export const load = async ({ depends }) => {
+	depends('app:teams', 'app:organizations');
+
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/api/events/+server.ts
+++ b/src/routes/api/events/+server.ts
@@ -1,0 +1,64 @@
+import type { RequestHandler } from './$types';
+import { loadContest } from '$lib/state.svelte';
+import type { ContestListener } from '@icpctools/contest-api';
+
+export const GET: RequestHandler = async () => {
+	const contest = await loadContest();
+
+	if (!contest) {
+		return new Response('Contest not loaded', { status: 500 });
+	}
+
+	// Create a readable stream for SSE
+	const stream = new ReadableStream({
+		start(controller) {
+			const encoder = new TextEncoder();
+
+			// Send initial connection message
+			const initMessage = `data: ${JSON.stringify({ type: 'connected', timestamp: new Date().toISOString() })}\n\n`;
+			controller.enqueue(encoder.encode(initMessage));
+
+			// Create listener for contest changes
+			const listener: ContestListener = (event) => {
+				try {
+					const message = `data: ${JSON.stringify(event)}\n\n`;
+					controller.enqueue(encoder.encode(message));
+				} catch (error) {
+					if (error instanceof TypeError) {
+						console.error('Error sending SSE event:', error.message);
+					} else {
+						console.error('Error sending SSE event:', error);
+					}
+				}
+			};
+
+			// Add listener to contest
+			contest.addChangeListener(listener);
+
+			// Keep-alive ping every 30 seconds
+			const keepAliveInterval = setInterval(() => {
+				try {
+					controller.enqueue(encoder.encode(': keep-alive\n\n'));
+				} catch (error) {
+					console.error('Error sending keep-alive:', error);
+					clearInterval(keepAliveInterval);
+				}
+			}, 30000);
+
+			// Cleanup on stream close
+			return () => {
+				clearInterval(keepAliveInterval);
+				contest.removeChangeListener(listener);
+				console.log('SSE client disconnected');
+			};
+		}
+	});
+
+	return new Response(stream, {
+		headers: {
+			'Content-Type': 'text/event-stream',
+			'Cache-Control': 'no-cache',
+			Connection: 'keep-alive'
+		}
+	});
+};

--- a/src/routes/clarifications/+page.server.ts
+++ b/src/routes/clarifications/+page.server.ts
@@ -24,7 +24,7 @@ function createClarData(c: Clarification, teams: Team[], groups: Group[], proble
 }
 
 export const load = async ({ depends }) => {
-	depends('data:clarifications');
+	depends('app:clarifications');
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/clarifications/+page.svelte
+++ b/src/routes/clarifications/+page.svelte
@@ -1,19 +1,7 @@
 <script lang="ts">
-	import { invalidate } from '$app/navigation';
-	import { onMount } from 'svelte';
 	import ClarificationUI from '$lib/ui/ClarificationUI.svelte';
 
 	let { data } = $props();
-
-	onMount(() => {
-		const interval = setInterval(() => {
-			invalidate('data:problem');
-		}, 3000);
-
-		return () => {
-			clearInterval(interval);
-		};
-	});
 </script>
 
 <div class="flex flex-col p-2 gap-1 h-full overflow-auto bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">

--- a/src/routes/map/+page.server.ts
+++ b/src/routes/map/+page.server.ts
@@ -1,7 +1,8 @@
 import { error } from '@sveltejs/kit';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async () => {
+export const load = async ({ depends }) => {
+	depends('app:teams', 'app:map-info');
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/problem/[id]/+page.server.ts
+++ b/src/routes/problem/[id]/+page.server.ts
@@ -5,7 +5,7 @@ import type { Judgement, JudgementType } from '@icpctools/contest-api';
 import type { SubmissionData } from '../../../lib/submissionData.js';
 
 export const load = async ({ params, depends }) => {
-	depends('data:problem');
+	depends('app:problems', 'app:submissions', 'app:judgements');
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { goto, invalidate } from '$app/navigation';
+	import { goto } from '$app/navigation';
 	import { ProblemUI } from '@icpctools/contest-ui';
-	import { onMount } from 'svelte';
 	import ReactionModal from '$lib/ui/ReactionModal.svelte';
 	import type { Column } from '$lib/ui/table/table.js';
 	import type { SubmissionData } from '../../../lib/submissionData.js';
@@ -18,16 +17,6 @@
 
 	let sourceModal = $state<SourceModal>();
 	let reactionModal = $state<ReactionModal>();
-
-	onMount(() => {
-		const interval = setInterval(() => {
-			invalidate('data:problem');
-		}, 3000);
-
-		return () => {
-			clearInterval(interval);
-		};
-	});
 
 	const columns: Column<SubmissionData>[] = [
 		{

--- a/src/routes/scoreboard/+page.server.ts
+++ b/src/routes/scoreboard/+page.server.ts
@@ -3,7 +3,7 @@ import { findById } from '@icpctools/contest-api';
 import { loadContest } from '$lib/state.svelte.js';
 
 export const load = async ({ depends }) => {
-	depends('data:scoreboard');
+	depends('app:teams', 'app:organizations', 'app:problems', 'app:scoreboard');
 
 	const cc = await loadContest();
 	if (!cc) throw error(404);
@@ -29,7 +29,6 @@ export const load = async ({ depends }) => {
 	const hasLogos = logos.filter((x) => x).length > 0;
 
 	return {
-		name: contest.name,
 		scoreboard_type: contest.scoreboard_type,
 		scoreboard: scoreboard,
 		teams: sortedTeams,

--- a/src/routes/scoreboard/+page.svelte
+++ b/src/routes/scoreboard/+page.svelte
@@ -1,21 +1,10 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { goto, invalidate } from '$app/navigation';
+	import { goto } from '$app/navigation';
 	import { flip } from 'svelte/animate';
 	import { ScoreboardHeader, ScoreboardRowUI } from '@icpctools/contest-ui';
 	import type { Problem } from '@icpctools/contest-api';
 
 	let { data } = $props();
-
-	onMount(() => {
-		const interval = setInterval(() => {
-			invalidate('data:scoreboard');
-		}, 1000);
-
-		return () => {
-			clearInterval(interval);
-		};
-	});
 </script>
 
 <div class="w-full h-full overflow-auto text-sm p-2 bg-white dark:bg-gray-900" role="table" aria-label="scoreboard">

--- a/src/routes/team/[id]/+layout.server.ts
+++ b/src/routes/team/[id]/+layout.server.ts
@@ -3,7 +3,7 @@ import { findById } from '@icpctools/contest-api';
 import { loadContest } from '$lib/state.svelte.js';
 
 export const load = async ({ params, depends }) => {
-	depends('data:team-layout');
+	depends('app:teams');
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/team/[id]/+layout.svelte
+++ b/src/routes/team/[id]/+layout.svelte
@@ -1,19 +1,7 @@
 <script lang="ts">
-	import { invalidate } from '$app/navigation';
 	import { Logo, ScoreboardRowUI } from '@icpctools/contest-ui';
-	import { onMount } from 'svelte';
 
 	let { data, children } = $props();
-
-	onMount(() => {
-		const interval = setInterval(() => {
-			invalidate('data:team-layout');
-		}, 3000);
-
-		return () => {
-			clearInterval(interval);
-		};
-	});
 </script>
 
 <div class="w-full h-full max-w-full max-h-full overflow-hidden flex flex-col bg-white dark:bg-gray-900">

--- a/src/routes/team/[id]/+page.server.ts
+++ b/src/routes/team/[id]/+page.server.ts
@@ -7,7 +7,7 @@ import { findManyBySubmissionId } from '@icpctools/contest-api';
 import { hasEndpointProperty } from '@icpctools/contest-api';
 
 export const load = async ({ params, depends }) => {
-	depends('data:team');
+	depends(`app:teams/{$params.id}`);
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { goto, invalidate } from '$app/navigation';
+	import { goto } from '$app/navigation';
 	import { Image, PersonUI } from '@icpctools/contest-ui';
-	import { onMount } from 'svelte';
 	import type { Column } from '$lib/ui/table/table';
 	import SimpleColumn from '$lib/ui/table/SimpleColumn.svelte';
 	import Table from '$lib/ui/table/Table.svelte';
@@ -77,16 +76,6 @@
 			})
 		});
 	}
-
-	onMount(() => {
-		const interval = setInterval(() => {
-			invalidate('data:team');
-		}, 3000);
-
-		return () => {
-			clearInterval(interval);
-		};
-	});
 </script>
 
 <div class="flex flex-col p-2 gap-1 h-full overflow-auto">


### PR DESCRIPTION
Several pages had timers that would invalidate themselves (reload) on fixed intervals, e.g. teams and problems pages would reload every 3s, scoreboard every 1s. In turn the backend has it's own polling of several Contest API endpoints every 5s.

This was simple, but it's inefficient and means we're reloading data even when nothing changed. On the server side we're slowly introducing the event feed; on the client side we need a similar mechanism.

This change adds:
- contest listeners that are fired whenever a type or individual object changes. The event feed will provide full notification when things actually change, but for now it fires every time the backend reloads an endpoint. The event includes the type and id.
- an /api/events endpoint that fires SSE ('server-sent events') to clients any time there's a contest change.
- a client-side listener that invalidates any registered pages.