### PR TITLE
feat: improved headers on source and reaction dialogs

### DIFF
--- a/src/lib/ui/Modal.svelte
+++ b/src/lib/ui/Modal.svelte
@@ -2,16 +2,16 @@
 	import type { Snippet } from 'svelte';
 
 	interface Props {
-		title?: string;
+		title?: Snippet;
 		children?: Snippet;
 	}
 
-	let { title = '', children }: Props = $props();
+	let { title, children }: Props = $props();
 
 	let show = $state(false);
 	let modal = $state<HTMLDivElement>();
 
-	export function open(newTitle?: string) {
+	export function open(newTitle?: Snippet) {
 		if (newTitle) {
 			title = newTitle;
 		}
@@ -55,9 +55,9 @@
 					flex flex-col"
 			role="dialog">
 			<!-- Header -->
-			<div class="flex flex-row items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-400">
-				<div class="font-semibold text-black dark:text-white">
-					{title}
+			<div class="flex flex-row items-start px-3 py-2 border-b border-gray-200 dark:border-gray-400">
+				<div class="text-black dark:text-white grow">
+					{@render title?.()}
 				</div>
 				<button onclick={close} class="hover:bg-hover p-1 rounded" aria-label="close"
 					><i class="fa-solid fa-xmark"></i></button>

--- a/src/lib/ui/ReactionModal.svelte
+++ b/src/lib/ui/ReactionModal.svelte
@@ -1,31 +1,51 @@
 <script lang="ts">
+	import type { SubmissionData } from '$lib/submissionData';
+	import { timeToMin } from '@icpctools/contest-api';
 	import Modal from './Modal.svelte';
-	import type { FileReference } from '@icpctools/contest-api';
-	import { Video } from '@icpctools/contest-ui';
+	import { JudgementUI, ProblemUI, Video } from '@icpctools/contest-ui';
 
 	let modal = $state<Modal>();
-	let reaction = $state<FileReference[]>();
 
-	export function openReaction(reaction2: FileReference[] | undefined, title: string) {
-		if (!reaction2) return;
+	let submission = $state<SubmissionData>();
 
-		reaction = reaction2;
-		modal?.open(title);
+	export function openReaction(newSubmission: SubmissionData) {
+		if (!newSubmission.reaction) {
+			return;
+		}
+
+		submission = newSubmission;
+		modal?.open();
 	}
 </script>
 
 <Modal bind:this={modal}>
-	{#if reaction?.length === 1}
-		<div class="flex w-full h-full bg-black place-content-center">
-			<Video ref={reaction[0]} type="reaction" />
+	{#snippet title()}
+		<div class="flex flex-col">
+			<div class="flex flex-row text-lg font-semibold pb-2">
+				{submission?.team.display_name ?? submission?.team.name}
+			</div>
+			<div class="flex flex-row gap-x-8 items-center">
+				<div class="flex flex-row gap-x-2">
+					Problem: <div class="w-10"><ProblemUI problem={submission?.problem} /></div>
+				</div>
+				<div class="flex flex-row gap-x-2">Time: {timeToMin(submission?.time)} minutes</div>
+				<div class="flex flex-row gap-x-2">
+					Judgement: <JudgementUI judgement={submission?.judgement} judgementType={submission?.judgementType} />
+				</div>
+			</div>
 		</div>
-	{:else if reaction?.length === 2}
+	{/snippet}
+	{#if submission?.reaction?.length === 1}
+		<div class="flex w-full h-full bg-black place-content-center">
+			<Video ref={submission?.reaction[0]} type="reaction" />
+		</div>
+	{:else if submission?.reaction?.length === 2}
 		<div class="flex w-full h-full bg-black">
 			<div class="flex w-1/2 h-full place-content-center">
-				<Video ref={reaction[0]} type="reaction" />
+				<Video ref={submission?.reaction[0]} type="reaction" />
 			</div>
 			<div class="flex w-1/2 h-full place-content-center">
-				<Video ref={reaction[1]} type="reaction" />
+				<Video ref={submission?.reaction[1]} type="reaction" />
 			</div>
 		</div>
 	{/if}

--- a/src/lib/ui/SourceModal.svelte
+++ b/src/lib/ui/SourceModal.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { fetchAndUnzipSubmission, getFileLanguage } from '$lib/source-util';
+	import type { SubmissionData } from '$lib/submissionData';
+	import { JudgementUI, ProblemUI } from '@icpctools/contest-ui';
 	import CodeEditor from './CodeEditor.svelte';
 	import Modal from './Modal.svelte';
-	import type { FileReference } from '@icpctools/contest-api';
+	import { timeToMin } from '@icpctools/contest-api';
 
 	let modal = $state<Modal>();
 
@@ -11,13 +13,19 @@
 	let sourceCode = $state<string>('');
 	let language = $state('text');
 
-	export function openSource(files: FileReference[] | undefined, title: string, auth: string): void {
-		if (!files) return;
+	let submission = $state<SubmissionData>();
+
+	export function openSource(newSubmission: SubmissionData): void {
+		if (!newSubmission.files) {
+			return;
+		}
+
+		submission = newSubmission;
 
 		sourceFiles = [];
 		sourceCode = 'Loading...';
 
-		fetchAndUnzipSubmission(files, auth)
+		fetchAndUnzipSubmission(newSubmission.files, newSubmission.auth)
 			.then((map) => {
 				sourceMap = map;
 				if (!sourceMap) {
@@ -40,11 +48,27 @@
 				}
 			});
 
-		modal?.open(title);
+		modal?.open();
 	}
 </script>
 
 <Modal bind:this={modal}>
+	{#snippet title()}
+		<div class="flex flex-col">
+			<div class="flex flex-row text-lg font-semibold pb-2">
+				{submission?.team.display_name ?? submission?.team.name}
+			</div>
+			<div class="flex flex-row gap-x-8 items-center">
+				<div class="flex flex-row gap-x-2">
+					Problem: <div class="w-10"><ProblemUI problem={submission?.problem} /></div>
+				</div>
+				<div class="flex flex-row gap-x-2">Time: {timeToMin(submission?.time)} minutes</div>
+				<div class="flex flex-row gap-x-2">
+					Judgement: <JudgementUI judgement={submission?.judgement} judgementType={submission?.judgementType} />
+				</div>
+			</div>
+		</div>
+	{/snippet}
 	<div class="flex flex-row w-full h-full bg-black place-content-center">
 		<div class="flex flex-col px-2">
 			Files:

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -53,12 +53,7 @@
 			renderer: SourceColumn,
 			rendererProps: (object: SubmissionData) => ({
 				source: object.files,
-				onclick: () =>
-					sourceModal?.openSource(
-						object.files,
-						object.team?.display_name || object.team?.name + ' source code',
-						object.auth
-					)
+				onclick: () => sourceModal?.openSource(object)
 			})
 		}
 	];
@@ -70,11 +65,7 @@
 			renderer: ReactionColumn,
 			rendererProps: (object: SubmissionData) => ({
 				reaction: object.reaction,
-				onclick: () =>
-					reactionModal?.openReaction(
-						object.reaction,
-						object.team?.display_name || object.team?.name + ' reaction video'
-					)
+				onclick: () => reactionModal?.openReaction(object)
 			})
 		});
 	}

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -50,12 +50,7 @@
 			renderer: SourceColumn,
 			rendererProps: (object: SubmissionData) => ({
 				source: object.files,
-				onclick: () =>
-					sourceModal?.openSource(
-						object.files,
-						object.team?.display_name || object.team?.name + ' source code',
-						object.auth
-					)
+				onclick: () => sourceModal?.openSource(object)
 			})
 		}
 	];
@@ -67,11 +62,7 @@
 			renderer: ReactionColumn,
 			rendererProps: (object: SubmissionData) => ({
 				reaction: object.reaction,
-				onclick: () =>
-					reactionModal?.openReaction(
-						object.reaction,
-						object.team?.display_name || object.team?.name + ' reaction video'
-					)
+				onclick: () => reactionModal?.openReaction(object)
 			})
 		});
 	}


### PR DESCRIPTION
This change does three things:
- simplifies the logic for the dialogs by just passing the submission data in.
- changes the modal dialog to allow a title snippet instead of just a string.
- uses this support to have a bigger title bar with the team name, problem, time, and judgement.

Fixes #149.

<img width="479" height="86" alt="Screenshot 2026-04-09 at 4 45 34 PM" src="https://github.com/user-attachments/assets/2d8b1e7f-9598-48d1-920f-124b594d46b5" />
