### PR TITLE
chore: fix sse client disconnected error

### DIFF
--- a/src/routes/api/events/+server.ts
+++ b/src/routes/api/events/+server.ts
@@ -10,9 +10,12 @@ export const GET: RequestHandler = async () => {
 	}
 
 	// Create a readable stream for SSE
+	let cleanup: (() => void) | undefined;
+
 	const stream = new ReadableStream({
 		start(controller) {
 			const encoder = new TextEncoder();
+			let isClosed = false;
 
 			// Send initial connection message
 			const initMessage = `data: ${JSON.stringify({ type: 'connected', timestamp: new Date().toISOString() })}\n\n`;
@@ -20,12 +23,15 @@ export const GET: RequestHandler = async () => {
 
 			// Create listener for contest changes
 			const listener: ContestListener = (event) => {
+				if (isClosed) return;
+
 				try {
 					const message = `data: ${JSON.stringify(event)}\n\n`;
 					controller.enqueue(encoder.encode(message));
 				} catch (error) {
-					if (error instanceof TypeError) {
-						console.error('Error sending SSE event:', error.message);
+					if (error instanceof TypeError && error.message.includes('Controller is already closed')) {
+						// Client disconnected, mark as closed to stop further attempts
+						cleanup?.();
 					} else {
 						console.error('Error sending SSE event:', error);
 					}
@@ -37,20 +43,36 @@ export const GET: RequestHandler = async () => {
 
 			// Keep-alive ping every 30 seconds
 			const keepAliveInterval = setInterval(() => {
+				if (isClosed) {
+					clearInterval(keepAliveInterval);
+					return;
+				}
+
 				try {
 					controller.enqueue(encoder.encode(': keep-alive\n\n'));
 				} catch (error) {
-					console.error('Error sending keep-alive:', error);
+					if (error instanceof TypeError && error.message.includes('Controller is already closed')) {
+						cleanup?.();
+					}
 					clearInterval(keepAliveInterval);
 				}
 			}, 30000);
 
-			// Cleanup on stream close
-			return () => {
+			// Cleanup function - can be called from both cancel() and stream close
+			cleanup = () => {
+				if (isClosed) return; // Already cleaned up
+				isClosed = true;
 				clearInterval(keepAliveInterval);
 				contest.removeChangeListener(listener);
 				console.log('SSE client disconnected');
 			};
+
+			// Return cleanup for stream close
+			return cleanup;
+		},
+		cancel() {
+			// Called when client disconnects
+			cleanup?.();
 		}
 	});
 

--- a/src/routes/proxy/[...path]/+server.ts
+++ b/src/routes/proxy/[...path]/+server.ts
@@ -1,6 +1,6 @@
 import { CONFIG, CONTEST } from '$lib/hardcoded.svelte';
 import type { RequestHandler } from './$types';
-import got from 'got';
+import got, { RequestError } from 'got';
 import { Readable } from 'node:stream';
 
 // Proxy will only support GET for now
@@ -72,7 +72,11 @@ async function proxyRequest(path: string, url: URL, request: Request): Promise<R
 			});
 
 			stream.on('error', (error) => {
-				console.error('Proxy stream error:', error);
+				if (error instanceof RequestError && error.response?.statusCode === 304) {
+					// ignore Not Modified error, normal response is fine
+					return;
+				}
+				console.error('Proxy stream error:', error.message);
 				resolve(
 					new Response(JSON.stringify({ error: 'Proxy request failed' }), {
 						status: 502,


### PR DESCRIPTION
If a client disconnected the SSE would continue to try to send, fail, and output a message to the console - indefinitely. This makes sure to clean up the listener and output in all cases.

Also reduced proxy logging verbosity, and avoid logging 304 error (because 304 Not Modified is not an error).

Fixes #195.