### PR TITLE
Event feed

### DIFF
--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -1,7 +1,10 @@
 /**
- * Copyright later.
+ * Contest API for getting data from a single contest. There are two basic ways of
+ * using it: calling loadXxx() on individual contest endpoints, or using
+ * watch() to connect to an event feed. After doing either, call getXxx() to get
+ * contest data.
  */
-import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
+import type { OptionsInit, OptionsOfTextResponseBody } from 'got';
 import got, { HTTPError, RequestError } from 'got';
 import type {
 	Access,
@@ -28,6 +31,7 @@ import type {
 	Submission,
 	Team
 } from './contest-types.js';
+import readline from 'node:readline';
 
 export interface Credentials {
 	user?: string;
@@ -40,6 +44,27 @@ export type ContestEvent = {
 };
 
 export type ContestListener = (event: ContestEvent) => void;
+
+class Mutex {
+	private first: boolean = true;
+	private queue: (() => void)[] = [];
+
+	async lock(): Promise<void> {
+		if (this.first) {
+			return new Promise<void>((resolve) => this.queue.push(resolve));
+		}
+	}
+
+	unlock(): void {
+		this.first = false;
+		if (this.queue.length > 0) {
+			const next = this.queue.shift();
+			next?.();
+		}
+	}
+}
+
+const mutex = new Mutex();
 
 export class ContestAPI {
 	private contest?: Contest;
@@ -78,6 +103,8 @@ export class ContestAPI {
 
 	private changeListeners: ContestListener[] = [];
 
+	private scoreboardInvalid: boolean = false;
+
 	constructor(contestURL: string, credentials?: Credentials, proxyURL?: string) {
 		if (!contestURL.endsWith('/')) {
 			contestURL += '/';
@@ -115,11 +142,11 @@ export class ContestAPI {
 	}
 
 	getHttpOptions(): OptionsOfTextResponseBody {
-		const httpsOptions: HttpsOptions = {
-			rejectUnauthorized: false
-		};
-		const options: OptionsOfTextResponseBody = {
-			https: httpsOptions,
+		return {
+			https: {
+				rejectUnauthorized: false
+				//certificateAuthority = this.certificates.getAllCertificates();
+			},
 			retry: { limit: 0 },
 			username: this.credentials?.user,
 			password: this.credentials?.password,
@@ -133,12 +160,6 @@ export class ContestAPI {
 				response: 2000
 			}
 		};
-
-		/*if (options.https) {
-			options.https.certificateAuthority = this.certificates.getAllCertificates();
-		}*/
-
-		return options;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -490,6 +511,7 @@ export class ContestAPI {
 				const obj = data as Contest;
 				this.processFileReferences(obj);
 				this.contest = obj;
+				mutex.unlock();
 				return;
 			}
 			case 'state': {
@@ -645,33 +667,116 @@ export class ContestAPI {
 		this.fireChange({ type: n.type, id: n.id });
 	}
 
-	watch(): void {
+	getStreamOptions(): OptionsInit & { isStream?: true } {
+		return {
+			https: {
+				rejectUnauthorized: false
+				//certificateAuthority = this.certificates.getAllCertificates();
+			},
+			retry: { limit: 0 },
+			username: this.credentials?.user,
+			password: this.credentials?.password,
+			// specify short timeouts
+			timeout: {
+				lookup: 2000,
+				connect: 2000,
+				secureConnect: 2000,
+				send: 10000
+			},
+			isStream: true
+		};
+	}
+
+	async readEventFeed(): Promise<void> {
+		const url = this.getURL('event-feed');
+		console.log(`Connecting to ${url}`);
+		try {
+			const stream = got.stream(url, this.getStreamOptions());
+
+			const rl = readline.createInterface({
+				input: stream,
+				crlfDelay: Infinity // Recognizes all instances of CR LF as a single line break
+			});
+
+			// TODO 120s timeout
+			for await (const line of rl) {
+				if (line && line.length > 0) {
+					const obj: Notification = JSON.parse(line, (_key, value) => {
+						return value === null ? undefined : value;
+					});
+					this.processNotification(obj);
+				}
+			}
+
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} catch (error: any) {
+			if (error instanceof HTTPError) {
+				throw new Error(`HTTP error ${error.response.statusCode} loading ${url}: ${error.response.statusMessage}`, {
+					cause: error
+				});
+			} else if (error instanceof RequestError) {
+				throw new Error(`Error loading ${url}: ${error.code}`, { cause: error });
+			} else {
+				throw new Error(`Unexpected error loading ${url}: ${error}`, { cause: error });
+			}
+		}
+		console.log(`Done connecting to ${url}`);
+	}
+
+	private reset(): void {
+		this.contest = undefined;
+		this.access = undefined;
+		this.state = undefined;
+		this.organizations = [];
+		this.groups = [];
+		this.teams = [];
+		this.persons = [];
+		this.accounts = [];
+		this.account = undefined;
+		this.languages = [];
+		this.judgementTypes = [];
+		this.problems = [];
+		this.submissions = [];
+		this.judgements = [];
+		this.runs = [];
+		this.clarifications = [];
+		this.commentary = [];
+		this.awards = [];
+		this.startStatus = [];
+		this.scoreboard = undefined;
+		this.mapInfo = undefined;
+	}
+
+	async watch(): Promise<void> {
 		if (this.interval) {
 			return;
 		}
 		console.log(`Watching ${this.id}`);
+
+		// reset the contest to empty arrays
+		this.reset();
+
+		// load the initial access and scoreboard endpoints since they're not in the feed
+		await this.loadAccess(true);
+		await this.loadScoreboard(true);
+
+		this.readEventFeed();
+
+		// wait for initial contest load
+		await mutex.lock();
+
 		this.interval = setInterval(async () => {
-			console.log(`Invalidating ${this.id}`);
 			try {
-				if (this.contest) {
-					await this.loadContest(true);
-				}
-				if (this.submissions) {
-					await this.loadSubmissions(true);
-				}
-				if (this.judgements) {
-					await this.loadJudgements(true);
-				}
-				if (this.clarifications) {
-					await this.loadClarifications(true);
-				}
-				if (this.scoreboard) {
+				if (this.scoreboardInvalid) {
+					this.scoreboardInvalid = false;
 					await this.loadScoreboard(true);
 				}
 			} catch (error: unknown) {
 				console.error(`Error reloading contest data: ${error}`);
 			}
-		}, 5000);
+		}, 2000);
+
+		console.log(`Done watching ${this.id}`);
 	}
 
 	unwatch(): void {
@@ -693,6 +798,9 @@ export class ContestAPI {
 	}
 
 	private fireChange(event: ContestEvent): void {
+		if (event.type === 'submissions' || event.type === 'judgements') {
+			this.scoreboardInvalid = true;
+		}
 		for (const listener of this.changeListeners) {
 			try {
 				listener(event);

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -56,7 +56,7 @@ export async function loadContest(): Promise<ContestAPI | undefined> {
 		}
 
 		contest = contests.getContest(CONTEST?.contest_id);
-		contest?.watch();
+		await contest?.watch();
 		return contest;
 	} finally {
 		mutex.unlock();

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -3,12 +3,9 @@ import { error } from '@sveltejs/kit';
 import { hasEndpoint } from '@icpctools/contest-api';
 
 export const load = async ({ depends }) => {
+	depends('app:contest');
 	const cc = await loadContest();
 	if (!cc) throw error(404);
-
-	depends('app:contest');
-
-	await Promise.all([cc.loadContest(), cc.loadAccess()]);
 
 	const contest = cc.getContest();
 	if (!contest) throw error(404);

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -4,11 +4,8 @@ import { loadContest } from '$lib/state.svelte.js';
 
 export const load = async ({ depends }) => {
 	depends('app:teams', 'app:organizations');
-
 	const cc = await loadContest();
 	if (!cc) throw error(404);
-
-	await Promise.all([cc.loadTeams(), cc.loadOrganizations()]);
 
 	const teams = cc.getTeams();
 

--- a/src/routes/clarifications/+page.server.ts
+++ b/src/routes/clarifications/+page.server.ts
@@ -28,14 +28,6 @@ export const load = async ({ depends }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([
-		cc.loadGroups(),
-		cc.loadOrganizations(),
-		cc.loadTeams(),
-		cc.loadProblems(),
-		cc.loadClarifications()
-	]);
-
 	const problems = cc.getProblems();
 
 	const teams = cc.getTeams();

--- a/src/routes/map/+page.server.ts
+++ b/src/routes/map/+page.server.ts
@@ -6,15 +6,6 @@ export const load = async ({ depends }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await cc.loadTeams();
-
-	// map endpoint may not exist, so load it separately
-	try {
-		await cc.loadMapInfo();
-	} catch (error) {
-		console.log(`Could not load map: ${error}`);
-	}
-
 	return {
 		mapInfo: cc.getMapInfo(),
 		teams: cc.getTeams()

--- a/src/routes/problem/[id]/+page.server.ts
+++ b/src/routes/problem/[id]/+page.server.ts
@@ -9,16 +9,6 @@ export const load = async ({ params, depends }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([
-		cc.loadAccess(),
-		cc.loadTeams(),
-		cc.loadLanguages(),
-		cc.loadProblems(),
-		cc.loadJudgementTypes(),
-		cc.loadSubmissions(),
-		cc.loadJudgements()
-	]);
-
 	const problems = cc.getProblems();
 
 	const problem = problems?.find((p) => p.id && p.id === params.id);

--- a/src/routes/scoreboard/+page.server.ts
+++ b/src/routes/scoreboard/+page.server.ts
@@ -8,8 +8,6 @@ export const load = async ({ depends }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([cc.loadContest(), cc.loadTeams(), cc.loadOrganizations(), cc.loadProblems(), cc.loadScoreboard()]);
-
 	const contest = cc.getContest();
 	if (!contest) throw error(404);
 

--- a/src/routes/team/[id]/+layout.server.ts
+++ b/src/routes/team/[id]/+layout.server.ts
@@ -7,8 +7,6 @@ export const load = async ({ params, depends }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([cc.loadContest(), cc.loadTeams(), cc.loadOrganizations(), cc.loadProblems(), cc.loadScoreboard()]);
-
 	const teams = cc.getTeams();
 	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);

--- a/src/routes/team/[id]/+page.server.ts
+++ b/src/routes/team/[id]/+page.server.ts
@@ -11,19 +11,6 @@ export const load = async ({ params, depends }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([
-		cc.loadAccess(),
-		cc.loadGroups(),
-		cc.loadOrganizations(),
-		cc.loadTeams(),
-		cc.loadPersons(),
-		cc.loadLanguages(),
-		cc.loadProblems(),
-		cc.loadJudgementTypes(),
-		cc.loadSubmissions(),
-		cc.loadJudgements()
-	]);
-
 	const teams = cc.getTeams();
 	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);

--- a/src/routes/team/[id]/desktop/+page.server.ts
+++ b/src/routes/team/[id]/desktop/+page.server.ts
@@ -5,8 +5,6 @@ export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([cc.loadTeams()]);
-
 	const teams = cc.getTeams();
 	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);

--- a/src/routes/team/[id]/pip/+page.server.ts
+++ b/src/routes/team/[id]/pip/+page.server.ts
@@ -5,8 +5,6 @@ export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([cc.loadTeams()]);
-
 	const teams = cc.getTeams();
 	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);

--- a/src/routes/team/[id]/rpip/+page.server.ts
+++ b/src/routes/team/[id]/rpip/+page.server.ts
@@ -5,8 +5,6 @@ export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([cc.loadTeams()]);
-
 	const teams = cc.getTeams();
 	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);

--- a/src/routes/team/[id]/side-side/+page.server.ts
+++ b/src/routes/team/[id]/side-side/+page.server.ts
@@ -5,8 +5,6 @@ export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([cc.loadTeams()]);
-
 	const teams = cc.getTeams();
 	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);

--- a/src/routes/team/[id]/webcam/+page.server.ts
+++ b/src/routes/team/[id]/webcam/+page.server.ts
@@ -1,14 +1,12 @@
 import { error } from '@sveltejs/kit';
 import { loadContest } from '$lib/state.svelte.js';
 
-export const load = async (params) => {
+export const load = async ({ params }) => {
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 
-	await Promise.all([cc.loadTeams()]);
-
 	const teams = cc.getTeams();
-	const team = teams?.find((t) => t.id && t.id === params.params.id);
+	const team = teams?.find((t) => t.id && t.id === params.id);
 	if (!team) throw error(404);
 
 	return {


### PR DESCRIPTION
The Contest API has changed to support two modes: load individual endpoints, or
use watch() to connect to the event feed. In the event feed mode it loads the
access and scoreboard endpoints up front, connects to the feed, and waits for
the first contest event (using a Mutex) before returning.

Whenever there are changes to submissions or judgements the scoreboard is
triggered as invalid, and a separate timer checks every 2s and reloads it.

All of the calls to loadXxx() have been removed from the app to switch to the
feed, and some minor changes to make all of the *server.ts consistent.

There are several seconds of delay loading a large (e.g. finished) contest,
some obvious optimizations to be made (e.g. #202 ignore runs) and undoubtedly
a few regressions on initial loading/mutex, reconnection, reactivity, etc. However,
it works, changes reach the UI much faster, we don't miss changes to other
contest types / don't have to poll for more types. It's time to make this
the default so that we can extend the app in new ways and start finding any
remaining issues.

Fixes #29.