### PR TITLE
chore: invalid param and invalidation debouncing

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,21 +8,47 @@
 	import { ModeWatcher } from 'mode-watcher';
 	import type { ContestEvent } from '@icpctools/contest-api';
 	import ICPCtools from '$lib/ui/ICPCtools.svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 
 	let { data, children } = $props();
 
 	onMount(() => {
 		const eventSource = new EventSource('/api/events');
 
+		// debounce invalidations to avoid blocking the UI
+		let invalidateTimer: ReturnType<typeof setTimeout> | null = null;
+		const pendingInvalidations = new SvelteSet<string>();
+
+		function scheduleInvalidate(key: string) {
+			pendingInvalidations.add(key);
+
+			if (invalidateTimer) {
+				clearTimeout(invalidateTimer);
+			}
+
+			invalidateTimer = setTimeout(() => {
+				for (const k of pendingInvalidations) {
+					invalidate(k);
+				}
+				pendingInvalidations.clear();
+				invalidateTimer = null;
+			}, 100);
+		}
+
 		eventSource.onmessage = (event) => {
 			try {
 				const change: ContestEvent = JSON.parse(event.data);
 
+				if (change.type === 'connected') {
+					console.log('SSE connected');
+					return;
+				}
+
 				// invalidate any page containing the specific object or all objects of that type
 				if (change.id) {
-					invalidate('app:' + change.type + '/' + change.id);
+					scheduleInvalidate('app:' + change.type + '/' + change.id);
 				}
-				invalidate('app:' + change.type);
+				scheduleInvalidate('app:' + change.type);
 			} catch (error) {
 				console.error('Error processing SSE event:', error);
 			}
@@ -34,6 +60,9 @@
 		};
 
 		return () => {
+			if (invalidateTimer) {
+				clearTimeout(invalidateTimer);
+			}
 			eventSource.close();
 		};
 	});

--- a/src/routes/team/[id]/+layout.server.ts
+++ b/src/routes/team/[id]/+layout.server.ts
@@ -3,7 +3,7 @@ import { findById } from '@icpctools/contest-api';
 import { loadContest } from '$lib/state.svelte.js';
 
 export const load = async ({ params, depends }) => {
-	depends(`app:teams/{$params.id}`, 'app:problems', 'app:submissions', 'app:scoreboard');
+	depends(`app:teams/${params.id}`, 'app:problems', 'app:submissions', 'app:scoreboard');
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 

--- a/src/routes/team/[id]/+page.server.ts
+++ b/src/routes/team/[id]/+page.server.ts
@@ -7,7 +7,7 @@ import { findManyBySubmissionId } from '@icpctools/contest-api';
 import { hasEndpointProperty } from '@icpctools/contest-api';
 
 export const load = async ({ params, depends }) => {
-	depends(`app:teams/{$params.id}`, 'app:submissions');
+	depends(`app:teams/${params.id}`, 'app:submissions');
 	const cc = await loadContest();
 	if (!cc) throw error(404);
 


### PR DESCRIPTION
Two of the depends() calls had invalid syntax and need to be fixed (page invalidation for a specific team).

Also debounced invalidation so that if there are many SSE updates at once it doesn't flood the UI.