### PR TITLE
chore: navigation util

### DIFF
--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import type { Problem, Team } from '@icpctools/contest-api';
+import { gotoTeam, gotoTeamId, gotoProblem } from './navigation.js';
+import { resolve } from '$app/paths';
+import { goto } from '$app/navigation';
+
+vi.mock('$app/navigation');
+vi.mock('$app/paths');
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(resolve).mockImplementation((path) => path as ReturnType<typeof resolve>);
+	vi.mocked(goto).mockResolvedValue(undefined);
+});
+
+describe('gotoTeam', () => {
+	test('navigates to team page with team object', async () => {
+		const team: Team = {
+			id: 'team-123',
+			name: 'Test Team'
+		} as Team;
+
+		await gotoTeam(team);
+
+		expect(resolve).toHaveBeenCalledWith('/team/team-123');
+		expect(goto).toHaveBeenCalledWith('/team/team-123');
+	});
+
+	test('does not navigate when team is undefined', async () => {
+		await gotoTeam(undefined);
+
+		expect(resolve).not.toHaveBeenCalled();
+		expect(goto).not.toHaveBeenCalled();
+	});
+
+	test('does not navigate when team has no id', async () => {
+		const team = {} as Team;
+
+		await gotoTeam(team);
+
+		expect(resolve).not.toHaveBeenCalled();
+		expect(goto).not.toHaveBeenCalled();
+	});
+});
+
+describe('gotoTeamId', () => {
+	test('navigates to team page with team id', async () => {
+		await gotoTeamId('team-456');
+
+		expect(resolve).toHaveBeenCalledWith('/team/team-456');
+		expect(goto).toHaveBeenCalledWith('/team/team-456');
+	});
+
+	test('does not navigate when team id is undefined', async () => {
+		await gotoTeamId(undefined);
+
+		expect(resolve).not.toHaveBeenCalled();
+		expect(goto).not.toHaveBeenCalled();
+	});
+
+	test('does not navigate when team id is empty string', async () => {
+		await gotoTeamId('');
+
+		expect(resolve).not.toHaveBeenCalled();
+		expect(goto).not.toHaveBeenCalled();
+	});
+});
+
+describe('gotoProblem', () => {
+	test('navigates to problem page with problem object', async () => {
+		const problem: Problem = {
+			id: 'problem-a',
+			label: 'A',
+			name: 'Test Problem'
+		} as Problem;
+
+		await gotoProblem(problem);
+
+		expect(resolve).toHaveBeenCalledWith('/problem/problem-a');
+		expect(goto).toHaveBeenCalledWith('/problem/problem-a');
+	});
+
+	test('does not navigate when problem is undefined', async () => {
+		await gotoProblem(undefined);
+
+		expect(resolve).not.toHaveBeenCalled();
+		expect(goto).not.toHaveBeenCalled();
+	});
+
+	test('navigates to problem page when problem has no id', async () => {
+		const problem = {} as Problem;
+
+		await gotoProblem(problem);
+
+		expect(resolve).toHaveBeenCalledWith('/problem/undefined');
+		expect(goto).toHaveBeenCalledWith('/problem/undefined');
+	});
+});

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,21 @@
+import { goto } from '$app/navigation';
+import type { Problem, Team } from '@icpctools/contest-api';
+import { resolve } from '$app/paths';
+
+export async function gotoTeam(team?: Team): Promise<void> {
+	if (!team) return;
+
+	return gotoTeamId(team?.id);
+}
+
+export async function gotoTeamId(team_id?: string): Promise<void> {
+	if (!team_id) return;
+
+	return goto(resolve(`/team/${team_id}`));
+}
+
+export async function gotoProblem(problem?: Problem): Promise<void> {
+	if (!problem) return;
+
+	return goto(resolve(`/problem/${problem.id}`));
+}

--- a/src/lib/ui/ClarificationUI.svelte
+++ b/src/lib/ui/ClarificationUI.svelte
@@ -3,7 +3,7 @@
 	import type { ClarificationData } from '../../routes/clarifications/clarificationData';
 	import ClarificationUI from './ClarificationUI.svelte';
 	import TeamColumn from './table/TeamColumn.svelte';
-	import { goto } from '$app/navigation';
+	import { gotoTeam } from '$lib/navigation';
 
 	interface Props {
 		clar: ClarificationData;
@@ -21,7 +21,7 @@
 					team={clar.from_team}
 					logo={logos?.get(clar.from_team.id)}
 					noGap
-					onclick={() => goto(`/team/${clar.from_team?.id}`)} />
+					onclick={() => gotoTeam(clar.from_team)} />
 			{:else}
 				Jury
 			{/if}
@@ -32,7 +32,7 @@
 				To:
 				{#if clar.to_teams && clar.to_teams?.length > 0}
 					{#each clar.to_teams as team (team.id)}
-						<TeamColumn {team} logo={logos?.get(team.id)} noGap onclick={() => goto(`/team/${team.id}`)} />
+						<TeamColumn {team} logo={logos?.get(team.id)} noGap onclick={() => gotoTeam(team)} />
 					{/each}
 				{/if}
 				{#if clar.to_groups && clar.to_groups?.length > 0}

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+	import { gotoTeam } from '$lib/navigation.js';
 	import type { Team } from '@icpctools/contest-api';
 	import { FloorMap } from '@icpctools/contest-ui';
 
 	let { data } = $props();
 
 	let selected = $state<Team>();
-
-	function onClick(team: Team): void {
-		goto('/team/' + team.id);
-	}
 </script>
 
 <div class="flex flex-col w-full h-full bg-white dark:bg-gray-900">
 	<div class="gap-2 w-full grow overflow-hidden">
-		<FloorMap mapInfo={data.mapInfo} teams={data.teams} bind:selected onclick={(team: Team) => onClick(team)} />
+		<FloorMap mapInfo={data.mapInfo} teams={data.teams} bind:selected onclick={(team: Team) => gotoTeam(team)} />
 	</div>
 
 	<div class="text-center text-gray-900 dark:text-gray-100 p-2">Team: {selected?.display_name || selected?.name}</div>

--- a/src/routes/problem/[id]/+page.svelte
+++ b/src/routes/problem/[id]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { JudgementUI, ProblemUI } from '@icpctools/contest-ui';
 	import ReactionModal from '$lib/ui/ReactionModal.svelte';
 	import type { Column } from '$lib/ui/table/table.js';
@@ -11,6 +10,7 @@
 	import TeamColumn from '$lib/ui/table/TeamColumn.svelte';
 	import SourceModal from '$lib/ui/SourceModal.svelte';
 	import SourceColumn from '$lib/ui/table/SourceColumn.svelte';
+	import { gotoTeam } from '$lib/navigation.js';
 
 	let { data } = $props();
 
@@ -31,7 +31,7 @@
 			rendererProps: (object: SubmissionData) => ({
 				team: object.team,
 				logo: object.logo,
-				onclick: () => goto(`/team/${object.team?.id}`)
+				onclick: () => gotoTeam(object.team)
 			}),
 			comparator: (a, b): number =>
 				(a.team.display_name ?? a.team.name ?? 'a').localeCompare(b.team.display_name ?? b.team.name ?? 'a')

--- a/src/routes/scoreboard/+page.svelte
+++ b/src/routes/scoreboard/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { timeToMin, type ScoreboardRow } from '@icpctools/contest-api';
 	import type { Column } from '$lib/ui/table/table.js';
 	import Table from '$lib/ui/table/Table.svelte';
@@ -8,6 +7,7 @@
 	import TeamColumn from '$lib/ui/table/TeamColumn.svelte';
 	import ProblemColumn from '$lib/ui/table/ProblemColumn.svelte';
 	import ScoreboardSolved from '$lib/ui/table/ScoreboardSolved.svelte';
+	import { gotoProblem, gotoTeamId } from '$lib/navigation.js';
 
 	let { data } = $props();
 
@@ -26,7 +26,7 @@
 			rendererProps: (row: ScoreboardRow, index: number) => ({
 				team: data.teams[index],
 				logo: data.logos[index],
-				onclick: () => goto(`/team/${row.team_id}`)
+				onclick: () => gotoTeamId(row.team_id)
 			})
 		}
 	];
@@ -68,7 +68,7 @@
 			title: ProblemColumn,
 			titleProps: {
 				problem: probs()[i],
-				onclick: () => goto(`/problem/${data.problems[i].id}`)
+				onclick: () => gotoProblem(data.problems[i])
 			},
 			titleAlign: 'center',
 			renderer: ScoreboardProblem,

--- a/src/routes/team/[id]/+page.svelte
+++ b/src/routes/team/[id]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { Image, JudgementUI, PersonUI } from '@icpctools/contest-ui';
 	import type { Column } from '$lib/ui/table/table';
 	import SimpleColumn from '$lib/ui/table/SimpleColumn.svelte';
@@ -11,6 +10,7 @@
 	import type { SubmissionData } from '$lib/submissionData.js';
 	import SourceColumn from '$lib/ui/table/SourceColumn.svelte';
 	import SourceModal from '$lib/ui/SourceModal.svelte';
+	import { gotoProblem } from '$lib/navigation.js';
 
 	let { data } = $props();
 
@@ -29,7 +29,7 @@
 			renderer: ProblemColumn,
 			rendererProps: (object: SubmissionData) => ({
 				problem: object.problem,
-				onclick: () => goto(`/problem/${object.problem.id}`)
+				onclick: () => gotoProblem(object.problem)
 			}),
 			comparator: (a, b): number => a.problem.ordinal - b.problem.ordinal
 		},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { svelteTesting } from '@testing-library/svelte/vite';
 import tailwindcss from '@tailwindcss/vite';
 import type { Plugin } from 'vite';
@@ -64,5 +64,11 @@ export default defineConfig({
 			// Allow serving files from packages directory for module resolution
 			allow: ['..']
 		}
+	},
+	test: {
+		include: ['src/**/*.{test,spec}.{js,ts}'],
+		globals: true,
+		environment: 'jsdom',
+		alias: [{ find: '@testing-library/svelte', replacement: '@testing-library/svelte/svelte5' }]
 	}
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,10 +5,10 @@ import { configDefaults, defineConfig } from 'vitest/config';
  */
 export default defineConfig({
 	test: {
-		projects: ['packages/**/vite.config.{js,ts}'],
+		projects: ['packages/**/vite.config.{js,ts}', 'vite.config.ts'],
 		// use GitHub action reporters when running in CI
 		reporters: process.env.CI ? [['junit', { includeConsoleOutput: false }], 'default'] : ['default'],
 
-		exclude: [...configDefaults.exclude, '**/dist/**', '**/.{cache,git,output,temp,cdix}/**', '**/*.cdix/**']
+		exclude: [...configDefaults.exclude, '**/dist/**', '**/.*/**', '**/*.cdix/**']
 	}
 });


### PR DESCRIPTION
Several pages had hardcoded paths for team and problem pages, this just pulls it out to a common navigation utility so the routes are in one place.

When adding a test I realized that none of the tests in the root package are run in CI, so this enables that too.