### PR TITLE
chore: contest time cleanup

### DIFF
--- a/packages/contest-api/src/contest-time-util.test.ts
+++ b/packages/contest-api/src/contest-time-util.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { formatContestTime, getContestState, getContestTime, parseRelTime, timeToMin } from './contest-time-util.js';
+import { formatContestTime, getContestState, getContestClock, parseRelTime, timeToMin } from './contest-time-util.js';
 import type { Contest } from './contest-types.js';
 
 test('parseRelTime with number', () => {
@@ -90,21 +90,21 @@ test('getContestState with finished contest', () => {
 	expect(getContestState(contest)).toBe('finished');
 });
 
-test('getContestTime with undefined contest', () => {
-	expect(getContestTime(undefined, false)).toBeUndefined();
+test('getContestClock with undefined contest', () => {
+	expect(getContestClock(undefined, false)).toBeUndefined();
 });
 
-test('getContestTime when not scheduled', () => {
+test('getContestClock when not scheduled', () => {
 	const contest = {
 		id: 'test',
 		name: 'Test',
 		duration: '5:00:00',
 		scoreboard_type: 'pass-fail'
 	} as Contest;
-	expect(getContestTime(contest, false)).toBe('Contest not scheduled');
+	expect(getContestClock(contest)).toBeUndefined();
 });
 
-test('getContestTime when contest is over', () => {
+test('getContestClock when contest is over', () => {
 	const pastTime = new Date(Date.now() - 7200000).toISOString();
 	const contest = {
 		id: 'test',
@@ -113,5 +113,5 @@ test('getContestTime when contest is over', () => {
 		duration: '1:00:00',
 		scoreboard_type: 'pass-fail'
 	} as Contest;
-	expect(getContestTime(contest, false)).toBe('Contest is over');
+	expect(getContestClock(contest)).toBe('2:00:00');
 });

--- a/packages/contest-api/src/contest-time-util.ts
+++ b/packages/contest-api/src/contest-time-util.ts
@@ -107,7 +107,7 @@ export function getContestState(
 	return 'running';
 }
 
-export function getContestTime(contest: Contest | undefined, short: boolean): string | undefined {
+export function getContestClock(contest: Contest | undefined, currentTimeMs?: number): string | undefined {
 	if (!contest) {
 		return undefined;
 	}
@@ -119,37 +119,21 @@ export function getContestTime(contest: Contest | undefined, short: boolean): st
 
 	if (!contest.start_time) {
 		if (!contest.countdown_pause_time) {
-			return 'Contest not scheduled';
+			return undefined;
 		} else {
 			const pause = parseRelTime(contest.countdown_pause_time);
 			if (!pause) {
-				return 'Paused';
+				return undefined;
 			}
 
-			if (short) {
-				return formatContestTime(-pause * m, false) + ' (paused)';
-			} else {
-				return 'Countdown paused: ' + formatContestTime(-pause * m, false);
-			}
+			return formatContestTime(-pause * m, false);
 		}
 	}
 
 	const d = new Date(contest.start_time);
 
-	const time = (Date.now() - d.getTime()) * m; // - contest.getTimeDelta();
-	if (time < 0) {
-		if (short) {
-			return formatContestTime(time, true);
-		} else {
-			return 'Countdown: ' + formatContestTime(time, true);
-		}
-	}
-	const duration = parseRelTime(contest.duration);
-	if (duration && time > duration) {
-		return 'Contest is over';
-	}
-
-	return formatContestTime(time, true);
+	const currentTime = currentTimeMs ? currentTimeMs : Date.now();
+	return formatContestTime((currentTime - d.getTime()) * m, true);
 }
 
 export function formatContestTime(time: number, floor: boolean): string {

--- a/packages/contest-ui/src/lib/Clock.spec.ts
+++ b/packages/contest-ui/src/lib/Clock.spec.ts
@@ -19,11 +19,11 @@ test('Expect unscheduled styling', async () => {
 });
 
 test('Expect unscheduled styling', async () => {
-	await render(Clock, { contest: {} });
+	await render(Clock, { contest: {} as Contest });
 
 	const clock = screen.getByLabelText('contest clock');
 	expect(clock).toBeInTheDocument();
-	expect(clock).toHaveTextContent('Contest not scheduled');
+	expect(clock).toHaveTextContent('Not scheduled');
 	expect(clock).toHaveClass('text-gray-400');
 });
 
@@ -33,7 +33,7 @@ test('Expect paused styling', async () => {
 
 	const clock = screen.getByLabelText('contest clock');
 	expect(clock).toBeInTheDocument();
-	expect(clock).toHaveTextContent('-1:00:00 (paused)');
+	expect(clock).toHaveTextContent('-1:00:00');
 	expect(clock).toHaveClass('text-yellow-500');
 });
 

--- a/packages/contest-ui/src/lib/Clock.svelte
+++ b/packages/contest-ui/src/lib/Clock.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getContestTime, getContestState } from '@icpctools/contest-api';
+	import { getContestClock, getContestState } from '@icpctools/contest-api';
 	import type { Contest } from '@icpctools/contest-api';
 	import { onMount } from 'svelte';
 
@@ -8,17 +8,18 @@
 	}
 
 	let { contest }: Props = $props();
-	let clock: string | undefined = $derived('?');
+	let clockTime: string = $state('?');
 
-	let state = $derived(getContestState(contest));
+	let contestState = $derived(getContestState(contest));
+	let clock = $derived(clockTime);
 
 	onMount(() => {
 		// set initial value, then schedule updates
-		clock = getContestTime(contest, true);
+		clockTime = getContestClock(contest) || 'Not scheduled';
 
 		const clockInt = setInterval(
 			() => {
-				clock = getContestTime(contest, true);
+				clockTime = getContestClock(contest) || 'Not scheduled';
 			},
 			contest && contest.time_multiplier ? 50 : 350
 		);
@@ -33,11 +34,11 @@
 	aria-label="contest clock"
 	class={{
 		'whitespace-nowrap': true,
-		'text-gray-400': state === 'unscheduled',
-		'text-green-300': state === 'countdown',
-		'text-blue-200': state === 'frozen',
-		'text-gray-300': state === 'finished',
-		'text-yellow-500': state === 'paused'
+		'text-gray-400': contestState === 'unscheduled',
+		'text-green-300': contestState === 'countdown',
+		'text-blue-200': contestState === 'frozen',
+		'text-gray-300': contestState === 'finished',
+		'text-yellow-500': contestState === 'paused'
 	}}>
 	{clock}
 </span>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,7 +1,7 @@
 import { loadContest } from '$lib/state.svelte.js';
 
 export const load = async ({ depends }) => {
-	depends('app:contest');
+	depends('app:contest', 'app:state');
 	const cc = await loadContest();
 	if (!cc) {
 		return {


### PR DESCRIPTION
Similar to the changes I just did on ICPC tools, this updates the contest-api to have a single getContestClock() function that takes an optional time parameter. The Clock at the top is updated to use this, and fix reactivity so that the colour changes correctly on contest state.

The clock used to have words like '(paused)' and 'Contest is over', but these didn't fit in the UI correctly and made the function less reusable. Nothing else was using them (not the longer version) so it is all removed for now: clock is just the time.

First part of #218.