### PR TITLE
chore: remove ui hang

### DIFF
--- a/packages/contest-api/src/index.ts
+++ b/packages/contest-api/src/index.ts
@@ -1,5 +1,5 @@
 export * from './contest-api.js';
-export * from './contest-types.js';
+export type * from './contest-types.js';
 export * from './contest-time-util.js';
 export * from './contest-util.js';
 export * from './contests.js';

--- a/src/lib/hardcoded.svelte.ts
+++ b/src/lib/hardcoded.svelte.ts
@@ -1,16 +1,16 @@
 import { browser } from '$app/environment';
 
-export const CONTEST = $state(
-	browser
-		? {}
-		: {
-				url: process?.env?.CONTEST_URL || 'https://localhost:8443/api/',
-				contest_id: process?.env?.CONTEST_ID || undefined,
-				user: process?.env?.CONTEST_USER || 'admin',
-				password: process?.env?.CONTEST_PASSWORD || 'adm1n'
-			}
-);
+// Don't use $state for server-side singletons - it's meant for component reactivity
+// Using plain objects to avoid Svelte proxy issues in server-side load functions
+export const CONTEST = browser
+	? {}
+	: {
+			url: process?.env?.CONTEST_URL || 'https://localhost:8443/api/',
+			contest_id: process?.env?.CONTEST_ID || undefined,
+			user: process?.env?.CONTEST_USER || 'admin',
+			password: process?.env?.CONTEST_PASSWORD || 'adm1n'
+		};
 
-export const CONFIG = $state({
+export const CONFIG = {
 	proxy: process?.env?.CONTEST_PROXY ? process?.env?.CONTEST_PROXY === 'true' : process.env.NODE_ENV === 'development'
-});
+};

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -16,10 +16,11 @@ class Mutex {
 	}
 
 	unlock(): void {
-		this.locked = false;
 		if (this.queue.length > 0) {
 			const next = this.queue.shift();
 			next?.();
+		} else {
+			this.locked = false;
 		}
 	}
 }
@@ -27,11 +28,15 @@ class Mutex {
 const mutex = new Mutex();
 
 export async function loadContest(): Promise<ContestAPI | undefined> {
-	if (contest) return contest;
+	if (contest) {
+		return contest;
+	}
 
 	await mutex.lock();
 	try {
-		if (contest) return contest;
+		if (contest) {
+			return contest;
+		}
 
 		if (!CONTEST.url) {
 			console.error('CONTEST.url is not defined');

--- a/src/lib/ui/table/Table.svelte
+++ b/src/lib/ui/table/Table.svelte
@@ -79,9 +79,7 @@
 		const columnIndex = columns.findIndex((column) => column.title === defaultSortColumn);
 		if (columnIndex !== -1 && columns[columnIndex]?.comparator) {
 			sortColIndex = columnIndex;
-			sortAscending = columns[columnIndex].initialOrder
-				? columns[columnIndex].initialOrder !== 'descending'
-				: true;
+			sortAscending = columns[columnIndex].initialOrder ? columns[columnIndex].initialOrder !== 'descending' : true;
 		}
 	});
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,24 +22,32 @@
 		const maxReconnectDelay = 30000; // max 30 seconds
 		let isCleaningUp = false;
 
-		// debounce invalidations to avoid blocking the UI
+		// debounce invalidations with longer delay to avoid overwhelming the system
 		let invalidateTimer: ReturnType<typeof setTimeout> | undefined;
 		const pendingInvalidations = new SvelteSet<string>();
 
 		function scheduleInvalidate(key: string) {
+			// Limit queue size to prevent memory issues
+			if (pendingInvalidations.size > 100) {
+				console.warn(`Invalidation queue full, dropping: ${key}`);
+				return;
+			}
+
 			pendingInvalidations.add(key);
 
 			if (invalidateTimer) {
 				clearTimeout(invalidateTimer);
 			}
 
+			// Longer debounce (500ms instead of 100ms) to batch more events
 			invalidateTimer = setTimeout(() => {
+				// Process all invalidations at once (SvelteKit handles deduplication)
 				for (const k of pendingInvalidations) {
 					invalidate(k);
 				}
 				pendingInvalidations.clear();
 				invalidateTimer = undefined;
-			}, 100);
+			}, 500);
 		}
 
 		function connect() {


### PR DESCRIPTION
I had the UI hang a few times, so I spent some time with an agent going over all the possible causes. We found:
- a missing type import
- some unnecessary $state reactivity for server-side contest config
- the contest state mutex wasn't bulletproof
- client-side invalidation storms might be swamping Svelte
- some formatting fixes

Nothing was definitive, but I think the invalidation storm when connecting a new contest was likely the cause, and I haven't had the UI lock up since fixing these.