### PR TITLE
chore: add draft spec and api version

### DIFF
--- a/packages/contest-api/src/contest-api.test.ts
+++ b/packages/contest-api/src/contest-api.test.ts
@@ -3,6 +3,7 @@ import { ContestAPI, ContestEvent } from './contest-api.js';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { Response } from 'got';
+import { FileReference } from './contest-types.js';
 
 function getFile(contestId: string, type: string): string {
 	// use contest.json for the root
@@ -132,24 +133,25 @@ test('getURL', () => {
 test('resolveURL with absolute href', () => {
 	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
 	const ref = { href: 'https://cdn.example.com/logo.png', filename: 'logo.png', mime: 'image/png' };
-	expect(contestAPI.resolveURL(ref)).toBe('https://cdn.example.com/logo.png');
+	expect(contestAPI.resolveClientURL(ref)).toBe('https://cdn.example.com/logo.png');
 });
 
 test('resolveURL with server-relative href', () => {
 	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
 	const ref = { href: '/static/logo.png', filename: 'logo.png', mime: 'image/png' };
-	expect(contestAPI.resolveURL(ref)).toBe('https://api.example.com/static/logo.png');
+	expect(contestAPI.resolveClientURL(ref)).toBe('https://api.example.com/static/logo.png');
 });
 
 test('resolveURL with base-relative href', () => {
 	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
 	const ref = { href: 'contests/abc/logo.png', filename: 'logo.png', mime: 'image/png' };
-	expect(contestAPI.resolveURL(ref)).toBe('https://api.example.com/api/contests/abc/logo.png');
+	expect(contestAPI.resolveClientURL(ref)).toBe('https://api.example.com/api/contests/abc/logo.png');
 });
 
 test('resolveURL with undefined ref', () => {
 	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
-	expect(contestAPI.resolveURL(undefined)).toBeUndefined();
+	const ref = { filename: 'no-href.png', mime: 'image/png' } as FileReference;
+	expect(contestAPI.resolveClientURL(ref)).toBeUndefined();
 });
 
 test('getAuth', () => {

--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -29,7 +29,8 @@ import type {
 	Scoreboard,
 	StartStatus,
 	Submission,
-	Team
+	Team,
+	Version
 } from './contest-types.js';
 import readline from 'node:readline';
 
@@ -92,6 +93,7 @@ class InitialLoadGate {
 const initialLoadGate = new InitialLoadGate();
 
 export class ContestAPI {
+	private version?: Version;
 	private contest?: Contest;
 	private access?: Access;
 	private state?: ContestState;
@@ -118,6 +120,7 @@ export class ContestAPI {
 	private contestURL: string;
 	private baseURL: string;
 	private serverURL: string;
+	private proxyURL?: string;
 	private credentials?: Credentials;
 
 	private timeDelta = [];
@@ -140,31 +143,29 @@ export class ContestAPI {
 		}
 		this.contestURL = contestURL;
 		this.credentials = credentials;
+		this.proxyURL = proxyURL;
 
 		const bInd = this.contestURL.indexOf('/api/contests/');
 		this.id = this.contestURL.substring(bInd + 14, this.contestURL.length - 1);
 
 		// base url, e.g. http://example.com/api/
-		if (proxyURL) {
-			this.baseURL = proxyURL + '/';
-		} else {
-			this.baseURL = this.contestURL.substring(0, bInd + 5);
-		}
+		this.baseURL = this.contestURL.substring(0, bInd + 5);
 
 		// server url, e.g. http://example.com
-		if (proxyURL) {
-			this.serverURL = proxyURL + '/api';
-		} else {
-			const sInd = this.contestURL.indexOf('//');
-			const sInd2 = this.contestURL.indexOf('/', sInd + 2);
-			this.serverURL = this.contestURL.substring(0, sInd2);
-		}
+		const sInd = this.contestURL.indexOf('//');
+		const sInd2 = this.contestURL.indexOf('/', sInd + 2);
+		this.serverURL = this.contestURL.substring(0, sInd2);
 
 		//console.log('Contest URL: ' + this.contestURL);
 	}
 
 	getURL(type: string, id?: string): string {
 		if (id == null) {
+			if (type === 'contest') {
+				return this.contestURL;
+			} else if (type === 'version') {
+				return this.baseURL;
+			}
 			return this.contestURL + type;
 		}
 		return this.contestURL + type + '/' + id;
@@ -235,9 +236,15 @@ export class ContestAPI {
 		});*/
 	}
 
+	async loadVersion(force?: boolean): Promise<void> {
+		if (force || !this.version) {
+			this.version = await this.loadObject('version');
+		}
+	}
+
 	async loadContest(force?: boolean): Promise<void> {
 		if (force || !this.contest) {
-			this.contest = await this.loadObject('');
+			this.contest = await this.loadObject('contest');
 			this.fireChange({ type: 'contest' });
 		}
 	}
@@ -408,6 +415,9 @@ export class ContestAPI {
 	getContestURL(): string {
 		return this.contestURL;
 	}
+	getVersion(): Version | undefined {
+		return this.version;
+	}
 	getContest(): Contest | undefined {
 		return this.contest;
 	}
@@ -481,7 +491,7 @@ export class ContestAPI {
 		return total / this.timeDelta.length;
 	}
 
-	resolveURL(ref: FileReference | undefined): string | undefined {
+	resolveClientURL(ref: FileReference): string | undefined {
 		if (!ref || !ref.href) {
 			return undefined;
 		}
@@ -491,9 +501,15 @@ export class ContestAPI {
 		}
 		// Prepend server-relative URLs
 		if (ref.href.startsWith('/')) {
+			if (this.proxyURL) {
+				return this.proxyURL + '/api' + ref.href;
+			}
 			return this.serverURL + ref.href;
 		}
 		// ... and base-relative URLs
+		if (this.proxyURL) {
+			return this.proxyURL + '/' + ref.href;
+		}
 		return this.baseURL + ref.href;
 	}
 
@@ -522,7 +538,7 @@ export class ContestAPI {
 
 				for (const item of prop) {
 					if (this.isFileReference(item)) {
-						item.href = this.resolveURL(item) || item.href;
+						item.href = this.resolveClientURL(item) || item.href;
 					}
 				}
 			}
@@ -790,6 +806,7 @@ export class ContestAPI {
 	}
 
 	private reset(): void {
+		this.version = undefined;
 		this.contest = undefined;
 		this.access = undefined;
 		this.state = undefined;
@@ -826,7 +843,8 @@ export class ContestAPI {
 		// reset the contest to empty arrays
 		this.reset();
 
-		// load the initial access and scoreboard endpoints since they're not in the feed
+		// load the initial version, access, and scoreboard endpoints since they're not in the feed
+		await this.loadVersion(true);
 		await this.loadAccess(true);
 		await this.loadScoreboard(true);
 

--- a/packages/contest-api/src/contest-types.ts
+++ b/packages/contest-api/src/contest-types.ts
@@ -1,13 +1,14 @@
 /**
  * Contest API Types
  *
- * This file supports both the 2023-06 and 2026-01 Contest API specifications, with optional
- * extensions from the Contest Data Server (CDS). Inline comments are used to indicate objects
- * and properties that are unique to any of these.
+ * This file supports both the 2023-06 and 2026-01 Contest API specifications, the current
+ * future spec draft (2026-draft), and optional extensions from the Contest Data Server (CDS).
+ * Inline comments are used to indicate objects and properties that are unique to any of these.
  *
  * References:
  *  - 2023-06 Contest API: https://ccs-specs.icpc.io/2023-06/
  *  - 2026-01 Contest API: https://ccs-specs.icpc.io/2026-01/
+ *  - 2026-draft Contest API: https://ccs-specs.icpc.io (current future spec draft)
  *  - CDS extensions: https://github.com/icpctools/icpctools/blob/main/doc/spec-extensions.md
  */
 
@@ -23,7 +24,7 @@ export interface Provider {
 	logo?: FileReference[];
 }
 
-export interface Info {
+export interface Version {
 	version: string;
 	version_url: string;
 	provider?: Provider;
@@ -77,6 +78,13 @@ export interface ContestState {
 	thawed?: Time;
 	finalized?: Time;
 	end_of_updates?: Time;
+	removed_intervals?: RemovedInterval[]; // 2026-draft spec
+}
+
+export interface RemovedInterval {
+	start: Time;
+	end?: Time;
+	contest_time: RelTime;
 }
 
 // CDS extension
@@ -158,7 +166,6 @@ export interface Organization {
 	twitter_hashtag?: string;
 	url?: string;
 	logo?: FileReference[];
-
 	audio?: FileReference[]; // CDS extension
 }
 
@@ -187,14 +194,20 @@ export interface Language {
 	name: string;
 }
 
+export interface PersonRole {
+	type: 'contestant' | 'coach' | 'staff' | 'other';
+	title?: string;
+	team_id?: Id;
+}
+
 export interface Person {
 	id: Id;
 	name: string;
 	team_ids?: Id[];
 	title?: string;
 	email?: string;
-	sex?: string;
-	role: 'contestant' | 'coach' | 'staff' | 'other';
+	sex?: 'male' | 'female';
+	role: 'contestant' | 'coach' | 'staff' | 'other' | PersonRole; // PersonRole only in 2026-draft spec
 	photo?: FileReference[];
 }
 
@@ -236,9 +249,9 @@ export interface Judgement {
 	score?: number;
 	current?: boolean; // 2026-01 spec
 	start_time: Time;
-	start_contest_time: RelTime;
+	start_contest_time?: RelTime; // optional only in 2026-draft spec
 	end_time: Time;
-	end_contest_time: RelTime;
+	end_contest_time?: RelTime; // optional only in 2026-draft spec
 	max_run_time: number;
 }
 
@@ -250,6 +263,7 @@ export interface Run {
 	time: Time;
 	contest_time: RelTime;
 	run_time: number;
+	score?: number; // 2026-draft spec
 }
 
 export interface Account {
@@ -257,7 +271,7 @@ export interface Account {
 	username: string;
 	password?: string;
 	name?: string;
-	type: 'team' | 'judge' | 'admin' | 'analyst' | 'staff';
+	type: 'team' | 'coach' | 'judge' | 'admin' | 'analyst' | 'staff'; // coach only in 2026-draft spec
 	ip?: string;
 	team_id?: Id;
 	person_id?: Id;


### PR DESCRIPTION
Updates the contest api types to include the current draft spec.

Renames Info to Version to match the spec.

Updates the contest api to add support for version, and load the version before loading the event feed (just like access and scoreboard).

Loading the version means we need to save the original base api url until later, so I deferred determining client-side proxy urls until we need those urls in resolveClientURL (renamed because I was getting confused).

A step toward #218.