### PR TITLE
chore: fix contest clock to use state and add removed intervals

### DIFF
--- a/packages/contest-api/src/contest-time-util.test.ts
+++ b/packages/contest-api/src/contest-time-util.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
-import { formatContestTime, getContestState, getContestClock, parseRelTime, timeToMin } from './contest-time-util.js';
-import type { Contest } from './contest-types.js';
+import { formatContestTime, getContestClock, parseRelTime, timeToMin } from './contest-time-util.js';
+import type { Contest, ContestState } from './contest-types.js';
 
 test('parseRelTime with number', () => {
 	expect(parseRelTime(5)).toBe(5 * 60 * 1000);
@@ -52,66 +52,111 @@ test('formatContestTime with floor false', () => {
 	expect(formatContestTime(500, false)).toBe('0:00:01');
 });
 
-test('getContestState with undefined contest', () => {
-	expect(getContestState(undefined)).toBe('unscheduled');
-});
-
-test('getContestState with unscheduled contest', () => {
-	const contest = {
-		id: 'test',
-		name: 'Test',
-		duration: '5:00:00',
-		scoreboard_type: 'pass-fail'
-	} as Contest;
-	expect(getContestState(contest)).toBe('unscheduled');
-});
-
-test('getContestState with countdown', () => {
-	const futureTime = new Date(Date.now() + 3600000).toISOString();
-	const contest = {
-		id: 'test',
-		name: 'Test',
-		start_time: futureTime,
-		duration: '5:00:00',
-		scoreboard_type: 'pass-fail'
-	} as Contest;
-	expect(getContestState(contest)).toBe('countdown');
-});
-
-test('getContestState with finished contest', () => {
-	const pastTime = new Date(Date.now() - 7200000).toISOString();
-	const contest = {
-		id: 'test',
-		name: 'Test',
-		start_time: pastTime,
-		duration: '1:00:00',
-		scoreboard_type: 'pass-fail'
-	} as Contest;
-	expect(getContestState(contest)).toBe('finished');
-});
-
-test('getContestClock with undefined contest', () => {
-	expect(getContestClock(undefined, false)).toBeUndefined();
+test('getContestClock with undefined parameters', () => {
+	expect(getContestClock(undefined, undefined)).toBeUndefined();
 });
 
 test('getContestClock when not scheduled', () => {
-	const contest = {
-		id: 'test',
-		name: 'Test',
-		duration: '5:00:00',
-		scoreboard_type: 'pass-fail'
-	} as Contest;
+	const contest = {} as Contest;
 	expect(getContestClock(contest)).toBeUndefined();
 });
 
-test('getContestClock when contest is over', () => {
-	const pastTime = new Date(Date.now() - 7200000).toISOString();
+test('getContestClock when scheduled', () => {
+	const startTime = new Date(Date.now() + 1800000).toISOString();
+	const contest = {
+		start_time: startTime
+	} as Contest;
+	expect(getContestClock(contest)).toBe('-0:30:00');
+});
+
+test('getContestClock when scheduled with time multiple', () => {
+	const startTime = new Date(Date.now() + 1800000).toISOString();
+	const contest = {
+		start_time: startTime,
+		time_multiplier: 2
+	} as Contest;
+	expect(getContestClock(contest)).toBe('-1:00:00');
+});
+
+test('getContestClock when countdown paused', () => {
+	const contest = {
+		countdown_pause_time: '1:00:00'
+	} as Contest;
+	expect(getContestClock(contest)).toBe('-1:00:00');
+});
+
+test('getContestClock when countdown paused with time mutliple', () => {
+	const contest = {
+		countdown_pause_time: '1:00:00',
+		time_multiplier: 2.5
+	} as Contest;
+	expect(getContestClock(contest)).toBe('-2:30:00');
+});
+
+test('getContestClock when contest in progress', () => {
+	const now = Date.now();
+	const pastTime = new Date(now - 3600000).toISOString();
 	const contest = {
 		id: 'test',
-		name: 'Test',
 		start_time: pastTime,
-		duration: '1:00:00',
-		scoreboard_type: 'pass-fail'
+		duration: '2:00:00'
 	} as Contest;
-	expect(getContestClock(contest)).toBe('2:00:00');
+	const state = {
+		started: pastTime
+	} as ContestState;
+	expect(getContestClock(contest, state, now)).toBe('1:00:00');
+});
+
+test('getContestClock when contest in progress with time multiple', () => {
+	const now = Date.now();
+	const startTime = new Date(now - 3600000).toISOString();
+	const contest = {
+		start_time: startTime,
+		time_multiplier: 2.5
+	} as Contest;
+	const state = {
+		started: startTime
+	} as ContestState;
+	expect(getContestClock(contest, state, now)).toBe('2:30:00');
+});
+
+test('getContestClock when contest is over', () => {
+	const now = Date.now();
+	const startTime = new Date(now - 7200000).toISOString();
+	const contest = {
+		start_time: startTime
+	} as Contest;
+	const state = {
+		started: startTime
+	} as ContestState;
+	expect(getContestClock(contest, state, now)).toBe('2:00:00');
+});
+
+test('getContestClock when contest in progress during removed interval', () => {
+	const now = Date.now();
+	const startTime = new Date(now - 7200000).toISOString();
+	const startIntervalTime = new Date(now - 3600000).toISOString();
+	const contest = {
+		start_time: startTime
+	} as Contest;
+	const state = {
+		started: startTime,
+		removed_intervals: [{ start: startIntervalTime, contest_time: '1:00:00' }]
+	} as ContestState;
+	expect(getContestClock(contest, state, now)).toBe('1:00:00');
+});
+
+test('getContestClock when contest in progress after removed interval', () => {
+	const now = Date.now();
+	const startTime = new Date(now - 7200000).toISOString();
+	const startIntervalTime = new Date(now - 3600000).toISOString();
+	const endIntervalTime = new Date(now - 1800000).toISOString();
+	const contest = {
+		start_time: startTime
+	} as Contest;
+	const state = {
+		started: startTime,
+		removed_intervals: [{ start: startIntervalTime, end: endIntervalTime, contest_time: '1:00:00' }]
+	} as ContestState;
+	expect(getContestClock(contest, state, now)).toBe('1:30:00');
 });

--- a/packages/contest-api/src/contest-time-util.ts
+++ b/packages/contest-api/src/contest-time-util.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright later.
  */
-import type { Contest, RelTime } from './contest-types.js';
+import type { Contest, ContestState, RelTime } from './contest-types.js';
 
 function isNumber(value: unknown): value is number {
 	return typeof value === 'number';
@@ -67,47 +67,7 @@ function formatTimeInMin(timeMs: number | undefined): string {
 	return sb.join('');
 }
 
-export function getContestState(
-	contest: Contest | undefined
-): 'unscheduled' | 'countdown' | 'paused' | 'running' | 'frozen' | 'finished' {
-	if (!contest) {
-		return 'unscheduled';
-	}
-
-	let m = 1;
-	if (contest.time_multiplier) {
-		m = contest.time_multiplier;
-	}
-
-	if (!contest.start_time) {
-		if (contest.countdown_pause_time) {
-			return 'paused';
-		}
-		return 'unscheduled';
-	}
-
-	const d = new Date(contest.start_time);
-
-	const time = (Date.now() - d.getTime()) * m; // - contest.getTimeDelta();
-	if (time < 0) {
-		return 'countdown';
-	}
-	const duration = parseRelTime(contest.duration);
-	if (duration) {
-		if (time > duration) {
-			return 'finished';
-		}
-
-		const freeze = parseRelTime(contest.scoreboard_freeze_duration);
-		if (freeze && time > duration - freeze) {
-			return 'frozen';
-		}
-	}
-
-	return 'running';
-}
-
-export function getContestClock(contest: Contest | undefined, currentTimeMs?: number): string | undefined {
+export function getContestClock(contest?: Contest, state?: ContestState, currentTimeMs?: number): string | undefined {
 	if (!contest) {
 		return undefined;
 	}
@@ -117,23 +77,52 @@ export function getContestClock(contest: Contest | undefined, currentTimeMs?: nu
 		m = contest.time_multiplier;
 	}
 
-	if (!contest.start_time) {
-		if (!contest.countdown_pause_time) {
+	// pause time
+	if (contest.countdown_pause_time) {
+		const pause = parseRelTime(contest.countdown_pause_time);
+		if (!pause) {
+			return undefined;
+		}
+
+		return formatContestTime(-pause * m, false);
+	}
+
+	// scheduled
+	const currentTime = currentTimeMs ?? Date.now();
+	if (!state?.started) {
+		if (!contest.start_time) {
 			return undefined;
 		} else {
-			const pause = parseRelTime(contest.countdown_pause_time);
-			if (!pause) {
-				return undefined;
-			}
-
-			return formatContestTime(-pause * m, false);
+			const d = new Date(contest.start_time);
+			return formatContestTime((currentTime - d.getTime()) * m, true);
 		}
 	}
 
-	const d = new Date(contest.start_time);
+	// started
+	const d = new Date(state.started);
 
-	const currentTime = currentTimeMs ? currentTimeMs : Date.now();
-	return formatContestTime((currentTime - d.getTime()) * m, true);
+	// apply removed intervals
+	let removedTime = 0;
+	if (state.removed_intervals) {
+		for (const interval of state.removed_intervals) {
+			const intervalStart = new Date(interval.start).getTime();
+			if (intervalStart < currentTime) {
+				// interval started before now, so it applies
+				if (!interval.end) {
+					// we're in the interval
+					return formatContestTime(parseRelTime(interval.contest_time) ?? 0, true);
+				}
+				const intervalEnd = new Date(interval?.end).getTime();
+				if (intervalEnd > currentTime) {
+					// we're in the interval
+					return formatContestTime(parseRelTime(interval.contest_time) ?? 0, true);
+				}
+				removedTime += intervalEnd - intervalStart;
+			}
+		}
+	}
+
+	return formatContestTime((currentTime - d.getTime() - removedTime) * m, true);
 }
 
 export function formatContestTime(time: number, floor: boolean): string {

--- a/packages/contest-ui/src/lib/Clock.spec.ts
+++ b/packages/contest-ui/src/lib/Clock.spec.ts
@@ -1,25 +1,30 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { expect, test, vi } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 
 import Clock from './Clock.svelte';
-import { Contest } from '@icpctools/contest-api';
+import { Contest, ContestState } from '@icpctools/contest-api';
 import { beforeEach } from 'vitest';
 
 beforeEach(() => {
+	vi.useFakeTimers();
 	vi.resetAllMocks();
 });
 
+afterEach(() => {
+	vi.useRealTimers();
+});
+
 test('Expect unscheduled styling', async () => {
-	await render(Clock);
+	render(Clock);
 
 	const clock = screen.getByLabelText('contest clock');
 	expect(clock).toBeInTheDocument();
 });
 
 test('Expect unscheduled styling', async () => {
-	await render(Clock, { contest: {} as Contest });
+	render(Clock, { contest: {} as Contest });
 
 	const clock = screen.getByLabelText('contest clock');
 	expect(clock).toBeInTheDocument();
@@ -29,7 +34,7 @@ test('Expect unscheduled styling', async () => {
 
 test('Expect paused styling', async () => {
 	const contest = { countdown_pause_time: '1:00:00.000' } as Contest;
-	await render(Clock, { contest: contest });
+	render(Clock, { contest: contest });
 
 	const clock = screen.getByLabelText('contest clock');
 	expect(clock).toBeInTheDocument();
@@ -39,7 +44,7 @@ test('Expect paused styling', async () => {
 
 test('Expect countdown styling', async () => {
 	const contest = { start_time: '2200-01-01T12:00:00+00:00' } as Contest;
-	await render(Clock, { contest: contest });
+	render(Clock, { contest: contest });
 
 	const clock = screen.getByLabelText('contest clock');
 	expect(clock).toBeInTheDocument();
@@ -52,9 +57,12 @@ test('Expect frozen styling', async () => {
 		duration: '99:00:00.000',
 		scoreboard_freeze_duration: '98:00:00.000'
 	} as Contest;
+	const state = {
+		frozen: '2026-03-03T12:00:00+00:00'
+	} as ContestState;
 	vi.spyOn(Date, 'now').mockReturnValue(1772569075932);
 
-	await render(Clock, { contest: contest });
+	render(Clock, { contest: contest, contestState: state });
 
 	const clock = screen.getByLabelText('contest clock');
 	expect(clock).toBeInTheDocument();
@@ -63,10 +71,12 @@ test('Expect frozen styling', async () => {
 
 test('Expect finished styling', async () => {
 	const contest = { start_time: '2000-01-01T12:00:00+00:00', duration: '5:00:00.000' } as Contest;
+	const state = {
+		ended: '2026-03-03T12:00:00+00:00'
+	} as ContestState;
 	// Mock Date.now to be after contest end (start 12:00 UTC + 5h duration)
-	vi.useFakeTimers();
 	vi.setSystemTime(new Date('2000-01-01T17:00:01Z'));
-	await render(Clock, { contest: contest });
+	render(Clock, { contest: contest, contestState: state });
 
 	const clock = screen.getByLabelText('contest clock');
 	expect(clock).toBeInTheDocument();

--- a/packages/contest-ui/src/lib/Clock.svelte
+++ b/packages/contest-ui/src/lib/Clock.svelte
@@ -1,27 +1,32 @@
 <script lang="ts">
-	import { getContestClock, getContestState } from '@icpctools/contest-api';
-	import type { Contest } from '@icpctools/contest-api';
+	import { getContestClock } from '@icpctools/contest-api';
+	import type { Contest, ContestState } from '@icpctools/contest-api';
 	import { onMount } from 'svelte';
 
 	interface Props {
 		contest?: Contest;
+		contestState?: ContestState;
 	}
 
-	let { contest }: Props = $props();
+	let { contest, contestState }: Props = $props();
 	let clockTime: string = $state('?');
 
-	let contestState = $derived(getContestState(contest));
-	let clock = $derived(clockTime);
+	let clock = $derived.by(() => {
+		return clockTime;
+	});
+
+	// store props in a reactive wrapper so the interval can access current values
+	let propsRef = $derived({ contest, contestState });
 
 	onMount(() => {
 		// set initial value, then schedule updates
-		clockTime = getContestClock(contest) || 'Not scheduled';
+		clockTime = getContestClock(propsRef.contest, propsRef.contestState) || 'Not scheduled';
 
 		const clockInt = setInterval(
 			() => {
-				clockTime = getContestClock(contest) || 'Not scheduled';
+				clockTime = getContestClock(propsRef.contest, propsRef.contestState) || 'Not scheduled';
 			},
-			contest && contest.time_multiplier ? 50 : 350
+			propsRef.contest?.time_multiplier ? 50 : 350
 		);
 
 		return () => {
@@ -34,11 +39,11 @@
 	aria-label="contest clock"
 	class={{
 		'whitespace-nowrap': true,
-		'text-gray-400': contestState === 'unscheduled',
-		'text-green-300': contestState === 'countdown',
-		'text-blue-200': contestState === 'frozen',
-		'text-gray-300': contestState === 'finished',
-		'text-yellow-500': contestState === 'paused'
+		'text-gray-400': !contest || !contest.start_time,
+		'text-green-300': contest?.start_time && !contestState?.started,
+		'text-blue-200': contestState?.frozen,
+		'text-gray-300': contestState?.ended,
+		'text-yellow-500': contest?.countdown_pause_time
 	}}>
 	{clock}
 </span>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -6,6 +6,7 @@ export const load = async ({ depends }) => {
 	if (!cc) {
 		return {
 			contest: null,
+			contestState: null,
 			name: null,
 			banner: null,
 			logo: null,
@@ -17,6 +18,7 @@ export const load = async ({ depends }) => {
 	if (!contest) {
 		return {
 			contest: null,
+			contestState: null,
 			name: null,
 			banner: null,
 			logo: null,
@@ -26,6 +28,7 @@ export const load = async ({ depends }) => {
 
 	return {
 		contest: contest,
+		contestState: cc.getState(),
 		name: contest.formal_name || contest.name,
 		banner: contest.banner,
 		logo: contest.logo,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -128,7 +128,7 @@
 
 			<div class="text-2xl w-full">{data.name}</div>
 
-			<div class="w-48"><Clock contest={data.contest} /></div>
+			<div class="w-48"><Clock contest={data.contest} contestState={data.contestState} /></div>
 
 			<div class="text-lg hover:bg-hover hover:text-link p-2 rounded-md">
 				<a href="/" class="flex flex-row items-center"><i class="fa-solid fa-people-group pr-2"></i>Teams</a>


### PR DESCRIPTION
Changes:
- Switches getContestClock() to correctly use contest state for start and end times.
- Adds draft support for removed_intervals to getContestClock().
- Updates Clock to accept contest state, use it to determine colour, and be reactive to changes.
- Removes now unused getContestState().

Fixes #218.