### PR TITLE
chore: contest type name validation

### DIFF
--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -14,6 +14,7 @@ import type {
 	Commentary,
 	Contest,
 	ContestState,
+	ContestType,
 	FileReference,
 	Group,
 	Id,
@@ -193,7 +194,7 @@ export class ContestAPI {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	async loadObject(type: string): Promise<any> {
+	async loadObject(type: ContestType): Promise<any> {
 		const startTime = performance.now();
 		const url = this.getURL(type);
 		try {

--- a/packages/contest-api/src/contest-types.ts
+++ b/packages/contest-api/src/contest-types.ts
@@ -12,6 +12,30 @@
  *  - CDS extensions: https://github.com/icpctools/icpctools/blob/main/doc/spec-extensions.md
  */
 
+export type ContestType =
+	| 'version'
+	| 'access'
+	| 'contest'
+	| 'judgement-types'
+	| 'languages'
+	| 'problems'
+	| 'groups'
+	| 'organizations'
+	| 'teams'
+	| 'persons'
+	| 'account'
+	| 'accounts'
+	| 'state'
+	| 'submissions'
+	| 'judgements'
+	| 'runs'
+	| 'clarifications'
+	| 'awards'
+	| 'commentary'
+	| 'scoreboard'
+	| 'map-info'
+	| 'start-status';
+
 export type Id = string;
 
 export type RelTime = string;
@@ -317,7 +341,7 @@ export interface StartStatus {
 }
 
 export interface Notification {
-	type: string;
+	type: ContestType;
 	id?: Id;
 	data?: { id: Id }[] | object;
 	token?: string;


### PR DESCRIPTION
Adds a ContestType enum to the contest types, and uses it for loading endpoints and notifications. This just ensures that both of these cases are typed and there are no unknown types or typos in the names of contest objects.