### PR TITLE
chore: rename change listener to contest listener

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ This allows client-side code to call `/proxy/...` endpoints without CORS issues 
 
 The `/api/events` route provides real-time contest updates via Server-Sent Events:
 
-- **ContestAPI Change Listeners** - The `ContestAPI` class supports registering change listeners that fire when contest data changes
+- **ContestAPI Contest Listeners** - The `ContestAPI` class supports registering contest listeners that fire when contest data changes
 - **Event Types** - Emits events for all contest data types: `contest`, `state`, `teams`, `submissions`, `judgements`, `clarifications`, `scoreboard`, etc.
 - **Event Structure** - `{ type: string, id?: string }`
 - **Auto-cleanup** - Listeners are automatically removed when clients disconnect

--- a/packages/contest-api/src/contest-api.test.ts
+++ b/packages/contest-api/src/contest-api.test.ts
@@ -3,7 +3,7 @@ import { ContestAPI, ContestEvent } from './contest-api.js';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { Response } from 'got';
-import { FileReference } from './contest-types.js';
+import { FileReference, Notification } from './contest-types.js';
 
 function getFile(contestId: string, type: string): string {
 	// use contest.json for the root
@@ -262,4 +262,71 @@ test('listener errors do not break other listeners', () => {
 	expect(consoleErrorSpy).toHaveBeenCalled();
 
 	consoleErrorSpy.mockRestore();
+});
+
+test('addContestModifier and fireChange', () => {
+	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
+	const events: Notification[] = [];
+
+	const listener = (event: Notification) => {
+		events.push(event);
+		return true;
+	};
+
+	contestAPI.addContestModifier(listener);
+
+	// Simulate a notification
+	contestAPI.processNotification({
+		type: 'teams',
+		id: '123',
+		data: { id: '123' }
+	});
+
+	expect(events.length).toBe(1);
+	expect(events[0].type).toBe('teams');
+	expect(events[0].id).toBe('123');
+	expect(contestAPI.getTeams().length).toBe(1);
+});
+
+test('contestModifier rejection', () => {
+	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
+	const events: Notification[] = [];
+
+	const listener = (event: Notification) => {
+		events.push(event);
+		return false;
+	};
+
+	contestAPI.addContestModifier(listener);
+
+	// Simulate a notification
+	contestAPI.processNotification({
+		type: 'teams',
+		id: '123',
+		data: { id: '123' }
+	});
+
+	expect(events.length).toBe(1);
+	expect(contestAPI.getTeams().length).toBe(0);
+});
+
+test('removeContestModifier', () => {
+	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
+	const events: Notification[] = [];
+
+	const listener = (event: Notification) => {
+		events.push(event);
+		return true;
+	};
+
+	contestAPI.addContestModifier(listener);
+	contestAPI.removeContestModifier(listener);
+
+	// Simulate a notification
+	contestAPI.processNotification({
+		type: 'teams',
+		id: '123'
+	});
+
+	expect(events.length).toBe(0);
 });

--- a/packages/contest-api/src/contest-api.test.ts
+++ b/packages/contest-api/src/contest-api.test.ts
@@ -167,7 +167,7 @@ test('getTimeDelta', () => {
 	expect(contestAPI.getTimeDelta()).toBe(0);
 });
 
-test('addChangeListener and fireChange', () => {
+test('addContestListener and fireChange', () => {
 	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
 	const events: ContestEvent[] = [];
 
@@ -175,7 +175,7 @@ test('addChangeListener and fireChange', () => {
 		events.push(event);
 	};
 
-	contestAPI.addChangeListener(listener);
+	contestAPI.addContestListener(listener);
 
 	// Simulate a notification
 	contestAPI.processNotification({
@@ -188,7 +188,7 @@ test('addChangeListener and fireChange', () => {
 	expect(events[0].id).toBe('123');
 });
 
-test('removeChangeListener', () => {
+test('removeContestListener', () => {
 	const contestAPI = new ContestAPI('https://api.example.com/api/contests/abc/');
 	const events: ContestEvent[] = [];
 
@@ -196,8 +196,8 @@ test('removeChangeListener', () => {
 		events.push(event);
 	};
 
-	contestAPI.addChangeListener(listener);
-	contestAPI.removeChangeListener(listener);
+	contestAPI.addContestListener(listener);
+	contestAPI.removeContestListener(listener);
 
 	// Simulate a notification
 	contestAPI.processNotification({
@@ -221,8 +221,8 @@ test('multiple listeners receive events', () => {
 		events2.push(event);
 	};
 
-	contestAPI.addChangeListener(listener1);
-	contestAPI.addChangeListener(listener2);
+	contestAPI.addContestListener(listener1);
+	contestAPI.addContestListener(listener2);
 
 	// Simulate a notification
 	contestAPI.processNotification({
@@ -249,8 +249,8 @@ test('listener errors do not break other listeners', () => {
 		events.push(event);
 	};
 
-	contestAPI.addChangeListener(errorListener);
-	contestAPI.addChangeListener(goodListener);
+	contestAPI.addContestListener(errorListener);
+	contestAPI.addContestListener(goodListener);
 
 	// Simulate a notification
 	contestAPI.processNotification({

--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -129,7 +129,7 @@ export class ContestAPI {
 
 	private unknownTypes: string[] = [];
 
-	private changeListeners: ContestListener[] = [];
+	private contestListeners: ContestListener[] = [];
 
 	private scoreboardInvalid: boolean = false;
 
@@ -880,14 +880,14 @@ export class ContestAPI {
 		clearInterval(this.interval);
 	}
 
-	addChangeListener(listener: ContestListener): void {
-		this.changeListeners.push(listener);
+	addContestListener(listener: ContestListener): void {
+		this.contestListeners.push(listener);
 	}
 
-	removeChangeListener(listener: ContestListener): void {
-		const index = this.changeListeners.indexOf(listener);
+	removeContestListener(listener: ContestListener): void {
+		const index = this.contestListeners.indexOf(listener);
 		if (index >= 0) {
-			this.changeListeners.splice(index, 1);
+			this.contestListeners.splice(index, 1);
 		}
 	}
 
@@ -895,11 +895,11 @@ export class ContestAPI {
 		if (event.type === 'submissions' || event.type === 'judgements') {
 			this.scoreboardInvalid = true;
 		}
-		for (const listener of this.changeListeners) {
+		for (const listener of this.contestListeners) {
 			try {
 				listener(event);
 			} catch (error) {
-				console.error('Error in change listener:', error);
+				console.error('Error in contest listener:', error);
 			}
 		}
 	}

--- a/packages/contest-api/src/contest-api.ts
+++ b/packages/contest-api/src/contest-api.ts
@@ -44,11 +44,9 @@ export type ContestEvent = {
 	id?: Id;
 };
 
-export type FeedOptions = {
-	ignore?: string[];
-};
-
 export type ContestListener = (event: ContestEvent) => void;
+
+export type ContestModifier = (event: Notification) => boolean;
 
 class InitialLoadGate {
 	private loaded: boolean = false;
@@ -130,10 +128,9 @@ export class ContestAPI {
 	private unknownTypes: string[] = [];
 
 	private contestListeners: ContestListener[] = [];
+	private contestModifiers: ContestModifier[] = [];
 
 	private scoreboardInvalid: boolean = false;
-
-	private ignore: string[] = [];
 
 	private shouldReconnect: boolean = false;
 
@@ -632,9 +629,10 @@ export class ContestAPI {
 	}
 
 	processNotification(n: Notification): void {
-		if (this.ignore.includes(n.type)) {
+		if (!this.modify(n)) {
 			return;
 		}
+
 		if ((!n.id || n.type === 'contest') && !Array.isArray(n.data)) {
 			// no id and not an array: must be a 'singleton' object (e.g. state)
 			this.processNotificationSingleton(n.type, n.data ?? {});
@@ -830,11 +828,7 @@ export class ContestAPI {
 		this.mapInfo = undefined;
 	}
 
-	async watch(options?: FeedOptions): Promise<void> {
-		if (options?.ignore) {
-			this.ignore = options.ignore;
-			console.log('Ignoring: ' + this.ignore);
-		}
+	async watch(): Promise<void> {
 		if (this.interval) {
 			return;
 		}
@@ -902,5 +896,29 @@ export class ContestAPI {
 				console.error('Error in contest listener:', error);
 			}
 		}
+	}
+
+	addContestModifier(modifier: ContestModifier): void {
+		this.contestModifiers.push(modifier);
+	}
+
+	removeContestModifier(modifier: ContestModifier): void {
+		const index = this.contestModifiers.indexOf(modifier);
+		if (index >= 0) {
+			this.contestModifiers.splice(index, 1);
+		}
+	}
+
+	private modify(event: Notification): boolean {
+		for (const modifier of this.contestModifiers) {
+			try {
+				if (!modifier(event)) {
+					return false;
+				}
+			} catch (error) {
+				console.error('Error in contest modifier:', error);
+			}
+		}
+		return true;
 	}
 }

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -62,7 +62,8 @@ export async function loadContest(): Promise<ContestAPI | undefined> {
 		}
 
 		contest = contests.getContest(CONTEST?.contest_id);
-		await contest?.watch({ ignore: ['runs'] });
+		contest?.addContestModifier((n) => n.type !== 'runs');
+		await contest?.watch();
 		return contest;
 	} catch (error) {
 		console.error('Error loading contest:', error);

--- a/src/routes/api/events/+server.ts
+++ b/src/routes/api/events/+server.ts
@@ -39,7 +39,7 @@ export const GET: RequestHandler = async () => {
 			};
 
 			// Add listener to contest
-			contest.addChangeListener(listener);
+			contest.addContestListener(listener);
 
 			// Keep-alive ping every 30 seconds
 			const keepAliveInterval = setInterval(() => {
@@ -63,7 +63,7 @@ export const GET: RequestHandler = async () => {
 				if (isClosed) return; // Already cleaned up
 				isClosed = true;
 				clearInterval(keepAliveInterval);
-				contest.removeChangeListener(listener);
+				contest.removeContestListener(listener);
 				console.log('SSE client disconnected');
 			};
 


### PR DESCRIPTION
Renames contest change listener to contest listener. It's more accurate,
matches the naming in the Java contest model, and will make more sense
when we add modifiers.

Signed-off-by: Tim deBoer <git@tdeboer.ca>